### PR TITLE
Corrige l'édition des voies

### DIFF
--- a/components/bal/voie-editor.js
+++ b/components/bal/voie-editor.js
@@ -21,6 +21,7 @@ function VoieEditor({initialValue, onSubmit, onCancel}) {
   const setRef = useFocus()
 
   const {
+    enabled,
     marker,
     enableMarker,
     disableMarker
@@ -84,7 +85,7 @@ function VoieEditor({initialValue, onSubmit, onCancel}) {
     } else {
       disableMarker()
     }
-  }, [initialValue, disableMarker, enableMarker, isToponyme])
+  }, [enabled, initialValue, disableMarker, enableMarker, isToponyme])
 
   return (
     <Pane is='form' onSubmit={onFormSubmit}>


### PR DESCRIPTION
Quand un nouvel `editingId` est assigné, `VoieEditor` désactive le marqueur de la carte quand la voie n'est pas un toponyme. Cependant `MarkerContextProvider` est lui aussi déclenché par `editingId` et vient ré-activer le marqueur.

Ajouté `enabled` au `useEffect` de `VoieEditor` permet d'empêcher ce comportement.

Fix #7 