### PR TITLE
Corrige l'édition des suffixes

### DIFF
--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -35,9 +35,7 @@ function NumeroEditor({initialValue, onSubmit, onCancel}) {
       numero: Number(numero)
     }
 
-    if (suffixe) {
-      body.suffixe = suffixe
-    }
+    body.suffixe = suffixe.length > 0 ? suffixe : null
 
     if (marker) {
       body.positions = [


### PR DESCRIPTION
Permet de définir `suffixe` à `null` afin de pouvoir le supprimer.

Fix #6 