### PR TITLE
Ajout du bouton "Publier"

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,2 +1,3 @@
-BAL_API_URL=http://localhost:5000/v1
+BAL_API_URL=https://api-bal.adresse.data.gouv.fr/v1
 GEO_API_URL=https://geo.api.gouv.fr
+ADRESSE_URL=https://adresse.data.gouv.fr

--- a/components/header.js
+++ b/components/header.js
@@ -28,7 +28,7 @@ const Header = React.memo(({baseLocale, commune, voie, layout, isSidebarHidden, 
     window.open(URL.createObjectURL(blob))
   }, [baseLocale._id])
   
-  const publicationUrl = `${BAL_API_URL}/bases-locales/${baseLocale._id}/csv`
+  const csvUrl = `${BAL_API_URL}/bases-locales/${baseLocale._id}/csv`
 
   return (
     <Pane
@@ -62,7 +62,7 @@ const Header = React.memo(({baseLocale, commune, voie, layout, isSidebarHidden, 
       />
 
       <Pane marginLeft='auto' display='flex'>
-        <NextLink href={`${ADRESSE_URL}/bases-locales/publication?url=${encodeURIComponent(publicationUrl)}`}>
+        <NextLink href={`${ADRESSE_URL}/bases-locales/publication?url=${encodeURIComponent(csvUrl)}`}>
           <a><Button height={24} appearance='primary'>Publier</Button></a>
         </NextLink>
 

--- a/components/header.js
+++ b/components/header.js
@@ -1,7 +1,7 @@
 import React, {useCallback, useContext} from 'react'
 import PropTypes from 'prop-types'
 import NextLink from 'next/link'
-import {Pane, Popover, Menu, IconButton, Position} from 'evergreen-ui'
+import {Pane, Popover, Menu, IconButton, Button, Position} from 'evergreen-ui'
 
 import {downloadBaseLocaleCsv} from '../lib/bal-api'
 
@@ -54,6 +54,10 @@ const Header = React.memo(({baseLocale, commune, voie, layout, isSidebarHidden, 
       />
 
       <Pane marginLeft='auto' display='flex'>
+        <NextLink href={`https://adresse.data.gouv.fr/bases-locales/publication?url=https://api-bal.adresse.data.gouv.fr/v1/bases-locales/${baseLocale._id}/csv`}>
+          <a><Button height={24} appearance='primary'>Publier</Button></a>
+        </NextLink>
+
         <Popover
           position={Position.BOTTOM_RIGHT}
           content={

--- a/components/header.js
+++ b/components/header.js
@@ -27,6 +27,8 @@ const Header = React.memo(({baseLocale, commune, voie, layout, isSidebarHidden, 
 
     window.open(URL.createObjectURL(blob))
   }, [baseLocale._id])
+  
+  const publicationUrl = `${BAL_API_URL}/bases-locales/${baseLocale._id}/csv`
 
   return (
     <Pane
@@ -60,7 +62,7 @@ const Header = React.memo(({baseLocale, commune, voie, layout, isSidebarHidden, 
       />
 
       <Pane marginLeft='auto' display='flex'>
-        <NextLink href={`${ADRESSE_URL}/bases-locales/publication?url=${BAL_API_URL}/bases-locales/${baseLocale._id}/csv`}>
+        <NextLink href={`${ADRESSE_URL}/bases-locales/publication?url=${encodeURIComponent(publicationUrl)}`}>
           <a><Button height={24} appearance='primary'>Publier</Button></a>
         </NextLink>
 

--- a/components/header.js
+++ b/components/header.js
@@ -1,6 +1,7 @@
 import React, {useCallback, useContext} from 'react'
 import PropTypes from 'prop-types'
 import NextLink from 'next/link'
+import getConfig from 'next/config'
 import {Pane, Popover, Menu, IconButton, Button, Position} from 'evergreen-ui'
 
 import {downloadBaseLocaleCsv} from '../lib/bal-api'
@@ -10,6 +11,11 @@ import TokenContext from '../contexts/token'
 import useWindowSize from '../hooks/window-size'
 
 import Breadcrumbs from './breadcrumbs'
+
+const {publicRuntimeConfig: {
+  ADRESSE_URL,
+  BAL_API_URL
+}} = getConfig()
 
 const Header = React.memo(({baseLocale, commune, voie, layout, isSidebarHidden, onToggle}) => {
   const {innerWidth} = useWindowSize()
@@ -54,7 +60,7 @@ const Header = React.memo(({baseLocale, commune, voie, layout, isSidebarHidden, 
       />
 
       <Pane marginLeft='auto' display='flex'>
-        <NextLink href={`https://adresse.data.gouv.fr/bases-locales/publication?url=https://api-bal.adresse.data.gouv.fr/v1/bases-locales/${baseLocale._id}/csv`}>
+        <NextLink href={`${ADRESSE_URL}/bases-locales/publication?url=${BAL_API_URL}/bases-locales/${baseLocale._id}/csv`}>
           <a><Button height={24} appearance='primary'>Publier</Button></a>
         </NextLink>
 


### PR DESCRIPTION
Ce nouveau bouton permet d'être redirigé vers l'outil de publication de Base Adresse Locale de `adresse.data.gouv.fr`.

![Capture d’écran 2019-04-10 à 18 42 39](https://user-images.githubusercontent.com/7040549/55897289-871a3180-5bc0-11e9-9388-36ed40b6b4e0.png)

⚠️ En attente de https://github.com/etalab/adresse.data.gouv.fr/pull/332
