### PR TITLE
Replace CSV download behavior

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -1,10 +1,10 @@
-import React, {useCallback, useContext} from 'react'
+import React, {useContext} from 'react'
 import PropTypes from 'prop-types'
 import NextLink from 'next/link'
 import getConfig from 'next/config'
 import {Pane, Popover, Menu, IconButton, Button, Position} from 'evergreen-ui'
 
-import {downloadBaseLocaleCsv} from '../lib/bal-api'
+import {getBaseLocaleCsvUrl} from '../lib/bal-api'
 
 import TokenContext from '../contexts/token'
 
@@ -13,22 +13,14 @@ import useWindowSize from '../hooks/window-size'
 import Breadcrumbs from './breadcrumbs'
 
 const {publicRuntimeConfig: {
-  ADRESSE_URL,
-  BAL_API_URL
+  ADRESSE_URL
 }} = getConfig()
 
 const Header = React.memo(({baseLocale, commune, voie, layout, isSidebarHidden, onToggle}) => {
   const {innerWidth} = useWindowSize()
   const {token} = useContext(TokenContext)
 
-  const onDownload = useCallback(async () => {
-    const res = await downloadBaseLocaleCsv(baseLocale._id)
-    const blob = await res.blob()
-
-    window.open(URL.createObjectURL(blob))
-  }, [baseLocale._id])
-  
-  const csvUrl = `${BAL_API_URL}/bases-locales/${baseLocale._id}/csv`
+  const csvUrl = getBaseLocaleCsvUrl(baseLocale._id)
 
   return (
     <Pane
@@ -71,9 +63,11 @@ const Header = React.memo(({baseLocale, commune, voie, layout, isSidebarHidden, 
           content={
             <Menu>
               <Menu.Group>
-                <Menu.Item icon='download' onSelect={onDownload}>
-                  Télécharger au format CSV
-                </Menu.Item>
+                <NextLink href={csvUrl}>
+                  <Menu.Item icon='download' is='a' href={csvUrl} color='inherit' textDecoration='none'>
+                    Télécharger au format CSV
+                  </Menu.Item>
+                </NextLink>
               </Menu.Group>
               {token && (
                 <>

--- a/lib/bal-api/index.js
+++ b/lib/bal-api/index.js
@@ -73,10 +73,8 @@ export function uploadBaseLocaleCsv(balId, file, token) {
   })
 }
 
-export function downloadBaseLocaleCsv(balId) {
-  return request(`/bases-locales/${balId}/csv`, {
-    json: false
-  })
+export function getBaseLocaleCsvUrl(balId) {
+  return `${BAL_API_URL}/bases-locales/${balId}/csv`
 }
 
 export function addCommune(balId, codeCommune, token) {


### PR DESCRIPTION
Previously the client was downloading the CSV file and give a local URL to the user.
In production, this behavior is blocked by Safari and by uBlock Origin.

The new behavior is just a link.