### PR TITLE
Corrige la sélection de numéro

### DIFF
--- a/components/map/map.js
+++ b/components/map/map.js
@@ -126,7 +126,7 @@ function Map({interactive, style: defaultStyle, baseLocale, commune, voie}) {
   const onClick = useCallback(event => {
     const feature = event.features && event.features[0]
 
-    if (feature) {
+    if (feature && feature.properties.idVoie) {
       const {idVoie} = feature.properties
       return Router.push(
         `/bal/voie?balId=${baseLocale._id}&codeCommune=${commune.code}&idVoie=${idVoie}`,


### PR DESCRIPTION
Il peut arriver que l'événement de clique soit déclenché par un layer du fond de carte. Cette PR vérifie que la `feature` est bien une adresse et comporte la propriété `idVoie`?