### PR TITLE
Corrige la recherche de commune

### DIFF
--- a/components/commune-search/commune-search.js
+++ b/components/commune-search/commune-search.js
@@ -14,7 +14,10 @@ function CommuneSearch({placeholder, exclude, innerRef, defaultSelectedItem, onS
       limit: 7
     })
 
-    setCommunes(result.filter(c => !exclude.includes(c.code)))
+    setCommunes(result
+      .filter(c => c.departement) // Filter communes without departements
+      .filter(c => !exclude.includes(c.code))
+    )
   }, 300, [exclude])
 
   return (


### PR DESCRIPTION
Certaines communes sans département comme "Alo - 98611" faisaient casser la recherche de commune. Ce correctif filtre ces communes.