### PR TITLE
Corrige les différents problèmes de linter

### DIFF
--- a/components/bal/commune-editor.js
+++ b/components/bal/commune-editor.js
@@ -95,4 +95,8 @@ CommuneEditor.propTypes = {
   onCancel: PropTypes.func
 }
 
+CommuneEditor.defaultProps = {
+  onCancel: null
+}
+
 export default CommuneEditor

--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -173,4 +173,9 @@ NumeroEditor.propTypes = {
   onCancel: PropTypes.func
 }
 
+NumeroEditor.defaultProps = {
+  initialValue: null,
+  onCancel: null
+}
+
 export default NumeroEditor

--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -56,14 +56,14 @@ function NumeroEditor({initialValue, onSubmit, onCancel}) {
       setError(error.message)
       setIsLoading(false)
     }
-  }, [onSubmit, numero, suffixe, marker, type])
+  }, [numero, suffixe, marker, type, onSubmit, disableMarker])
 
   const onFormCancel = useCallback(e => {
     e.preventDefault()
 
     disableMarker()
     onCancel()
-  }, [onCancel])
+  }, [disableMarker, onCancel])
 
   const submitLabel = useMemo(() => {
     if (isLoading) {
@@ -90,7 +90,7 @@ function NumeroEditor({initialValue, onSubmit, onCancel}) {
     } else {
       disableMarker()
     }
-  }, [initialValue, hasPositionEditor])
+  }, [initialValue, hasPositionEditor, enableMarker, position, disableMarker])
 
   return (
     <Pane is='form' onSubmit={onFormSubmit}>

--- a/components/bal/position-editor.js
+++ b/components/bal/position-editor.js
@@ -65,9 +65,14 @@ PositionEditor.propTypes = {
   marker: PropTypes.shape({
     latitude: PropTypes.number,
     longitude: PropTypes.number
-  }),
+  }).isRequired,
   alert: PropTypes.string,
-  onTypeChange: PropTypes.func
+  onTypeChange: PropTypes.func.isRequired
+}
+
+PositionEditor.defaultProps = {
+  type: 'entrée',
+  alert: null
 }
 
 export default PositionEditor

--- a/components/bal/voie-editor.js
+++ b/components/bal/voie-editor.js
@@ -55,14 +55,14 @@ function VoieEditor({initialValue, onSubmit, onCancel}) {
       setIsLoading(false)
       setError(error.message)
     }
-  }, [nom, marker, positionType, onSubmit])
+  }, [nom, marker, positionType, onSubmit, disableMarker])
 
   const onFormCancel = useCallback(e => {
     e.preventDefault()
 
     disableMarker()
     onCancel()
-  }, [onCancel])
+  }, [disableMarker, onCancel])
 
   const submitLabel = useMemo(() => {
     if (isLoading) {
@@ -85,7 +85,7 @@ function VoieEditor({initialValue, onSubmit, onCancel}) {
     } else {
       disableMarker()
     }
-  }, [enabled, initialValue, disableMarker, enableMarker, isToponyme])
+  }, [enabled, initialValue, disableMarker, enableMarker, isToponyme, position])
 
   return (
     <Pane is='form' onSubmit={onFormSubmit}>

--- a/components/bal/voie-editor.js
+++ b/components/bal/voie-editor.js
@@ -158,4 +158,9 @@ VoieEditor.propTypes = {
   onCancel: PropTypes.func
 }
 
+VoieEditor.defaultProps = {
+  initialValue: null,
+  onCancel: null
+}
+
 export default VoieEditor

--- a/components/breadcrumbs.js
+++ b/components/breadcrumbs.js
@@ -67,15 +67,18 @@ Breadcrumbs.propTypes = {
     _id: PropTypes.string.isRequired,
     nom: PropTypes.string
   }).isRequired,
-
   commune: PropTypes.shape({
     code: PropTypes.string.isRequired,
     nom: PropTypes.string
   }),
-
   voie: PropTypes.shape({
     nom: PropTypes.string.isRequired
   })
+}
+
+Breadcrumbs.defaultProps = {
+  commune: null,
+  voie: null
 }
 
 export default React.memo(Breadcrumbs)

--- a/components/commune-search/commune-search-field.js
+++ b/components/commune-search/commune-search-field.js
@@ -64,16 +64,29 @@ CommuneSearchField.propTypes = {
   ...CommuneSearch.propTypes,
 
   label: PropTypes.node.isRequired,
-  labelFor: PropTypes.string,
-  isRequired: PropTypes.bool,
   description: PropTypes.node,
   hint: PropTypes.node,
   validationMessage: PropTypes.node,
   inputHeight: PropTypes.number,
-  inputWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+  inputWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  disabled: PropTypes.bool,
+  required: PropTypes.bool,
+  isInvalid: PropTypes.bool,
+  appearance: PropTypes.string,
+  placeholder: PropTypes.string,
+  spellCheck: PropTypes.bool
 }
 
 CommuneSearchField.defaultProps = {
+  description: null,
+  hint: null,
+  validationMessage: null,
+  disabled: false,
+  required: false,
+  isInvalid: false,
+  appearance: null,
+  placeholder: null,
+  spellCheck: true,
   inputWidth: '100%',
   inputHeight: 32
 }

--- a/components/commune-search/commune-search.js
+++ b/components/commune-search/commune-search.js
@@ -67,8 +67,10 @@ CommuneSearch.propTypes = {
 }
 
 CommuneSearch.defaultProps = {
+  defaultSelectedItem: null,
   placeholder: 'Chercher une commune…',
   exclude: [],
+  innerRef: () => {},
   onSelect: () => {}
 }
 

--- a/components/header.js
+++ b/components/header.js
@@ -129,7 +129,16 @@ const Header = React.memo(({baseLocale, commune, voie, layout, isSidebarHidden, 
 Header.propTypes = {
   baseLocale: PropTypes.object.isRequired,
   commune: PropTypes.object,
-  voie: PropTypes.object
+  voie: PropTypes.object,
+  layout: PropTypes.oneOf(['fullscreen', 'sidebar']).isRequired,
+  isSidebarHidden: PropTypes.bool,
+  onToggle: PropTypes.func.isRequired
+}
+
+Header.defaultProps = {
+  commune: null,
+  voie: null,
+  isSidebarHidden: false
 }
 
 export default Header

--- a/components/layout/fullscreen.js
+++ b/components/layout/fullscreen.js
@@ -33,10 +33,14 @@ Fullscreen.propTypes = {
 
   // Ignored props
   isOpen: PropTypes.bool,
-  isHidden: PropTypes.bool,
-  size: PropTypes.number,
-  top: PropTypes.number,
-  onToggle: PropTypes.func
+  isHidden: PropTypes.bool.isRequired,
+  size: PropTypes.number.isRequired,
+  top: PropTypes.number.isRequired,
+  onToggle: PropTypes.func.isRequired
+}
+
+Fullscreen.defaultProps = {
+  isOpen: false
 }
 
 export default Fullscreen

--- a/components/map/control.js
+++ b/components/map/control.js
@@ -33,4 +33,8 @@ NumeroSwitch.propTypes = {
   onChange: PropTypes.func.isRequired
 }
 
+NumeroSwitch.defaultProps = {
+  enabled: true
+}
+
 export default NumeroSwitch

--- a/components/table-row.js
+++ b/components/table-row.js
@@ -4,18 +4,7 @@ import {Table, Popover, Menu, Position, IconButton, toaster} from 'evergreen-ui'
 
 import TokenContext from '../contexts/token'
 
-const TableRow = React.memo(({
-  id,
-  code,
-  label,
-  secondary,
-
-  isSelectable,
-
-  onSelect,
-  onEdit,
-  onRemove
-}) => {
+const TableRow = React.memo(({id, code, label, secondary, isSelectable, onSelect, onEdit, onRemove}) => {
   const {token} = useContext(TokenContext)
 
   const onClick = useCallback(e => {
@@ -84,11 +73,21 @@ const TableRow = React.memo(({
 })
 
 TableRow.propTypes = {
-  isSelectable: PropTypes.bool
+  id: PropTypes.string.isRequired,
+  code: PropTypes.string,
+  label: PropTypes.string.isRequired,
+  secondary: PropTypes.string,
+  isSelectable: PropTypes.bool,
+  onSelect: PropTypes.func.isRequired,
+  onEdit: PropTypes.func,
+  onRemove: PropTypes.func.isRequired
 }
 
 TableRow.defaultProps = {
-  isSelectable: true
+  code: null,
+  secondary: null,
+  isSelectable: true,
+  onEdit: null
 }
 
 export default TableRow

--- a/contexts/bal-data.js
+++ b/contexts/bal-data.js
@@ -110,4 +110,10 @@ BalDataContextProvider.propTypes = {
   idVoie: PropTypes.string
 }
 
+BalDataContextProvider.defaultProps = {
+  balId: null,
+  codeCommune: null,
+  idVoie: null
+}
+
 export default BalDataContext

--- a/contexts/token.js
+++ b/contexts/token.js
@@ -52,6 +52,11 @@ TokenContextProvider.propTypes = {
   token: PropTypes.string
 }
 
+TokenContextProvider.defaultProps = {
+  balId: null,
+  token: null
+}
+
 export const MarkerContextConsumer = TokenContext.Consumer
 
 export default TokenContext

--- a/hooks/fuse.js
+++ b/hooks/fuse.js
@@ -11,7 +11,7 @@ function useFuse(source, delay, options) {
       threshold: 0.4,
       ...options
     })
-  }, [source])
+  }, [options, source])
 
   useEffect(() => {
     setFiltered(source)

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -156,7 +156,9 @@ App.propTypes = {
 }
 
 App.defaultProps = {
-  query: {}
+  query: {},
+  error: null,
+  geojson: null
 }
 
 export default App

--- a/pages/bal/commune.js
+++ b/pages/bal/commune.js
@@ -1,4 +1,5 @@
 import React, {useState, useCallback, useContext} from 'react'
+import PropTypes from 'prop-types'
 import Router from 'next/router'
 import {Pane, Heading, Paragraph, Table, Button} from 'evergreen-ui'
 
@@ -189,6 +190,21 @@ Commune.getInitialProps = async ({baseLocale, commune}) => {
     commune,
     defaultVoies
   }
+}
+
+Commune.propTypes = {
+  baseLocale: PropTypes.shape({
+    _id: PropTypes.string.isRequired
+  }).isRequired,
+  commune: PropTypes.shape({
+    code: PropTypes.string.isRequired,
+    nom: PropTypes.string.isRequired
+  }).isRequired,
+  defaultVoies: PropTypes.array
+}
+
+Commune.defaultProps = {
+  defaultVoies: null
 }
 
 export default Commune

--- a/pages/bal/index.js
+++ b/pages/bal/index.js
@@ -1,4 +1,5 @@
 import React, {useState, useCallback, useContext} from 'react'
+import PropTypes from 'prop-types'
 import Router from 'next/router'
 import {Pane, Heading, Button, Table} from 'evergreen-ui'
 
@@ -145,6 +146,17 @@ Index.getInitialProps = async ({baseLocale}) => {
     defaultCommunes: communes,
     baseLocale
   }
+}
+
+Index.propTypes = {
+  baseLocale: PropTypes.shape({
+    _id: PropTypes.string.isRequired
+  }).isRequired,
+  defaultCommunes: PropTypes.array
+}
+
+Index.defaultProps = {
+  defaultCommunes: null
 }
 
 export default Index

--- a/pages/bal/settings.js
+++ b/pages/bal/settings.js
@@ -1,4 +1,5 @@
 import React, {useState, useContext, useEffect, useCallback} from 'react'
+import PropTypes from 'prop-types'
 import {Pane, Heading, TextInputField, TextInput, IconButton, Button, Alert, Spinner, Label, toaster} from 'evergreen-ui'
 
 import {updateBaseLocale} from '../../lib/bal-api'
@@ -169,4 +170,10 @@ Settings.getInitialProps = ({baseLocale}) => {
   }
 }
 
+Settings.propTypes = {
+  baseLocale: PropTypes.shape({
+    _id: PropTypes.string.isRequired,
+    nom: PropTypes.string.isRequired
+  }).isRequired
+}
 export default Settings

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -1,4 +1,5 @@
 import React, {useState, useCallback, useContext} from 'react'
+import PropTypes from 'prop-types'
 import {Pane, Paragraph, Heading, Table, Button} from 'evergreen-ui'
 
 import {addNumero, editNumero, removeNumero, getNumeros} from '../../lib/bal-api'
@@ -171,6 +172,19 @@ Voie.getInitialProps = async ({baseLocale, commune, voie}) => {
     voie,
     defaultNumeros
   }
+}
+
+Voie.propTypes = {
+  voie: PropTypes.shape({
+    _id: PropTypes.string.isRequired,
+    nom: PropTypes.string.isRequired,
+    positions: PropTypes.array.isRequired
+  }).isRequired,
+  defaultNumeros: PropTypes.array
+}
+
+Voie.defaultProps = {
+  defaultNumeros: null
 }
 
 export default Voie

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -144,7 +144,7 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
                 id={numero._id}
                 isSelectable={!isAdding && !editingId && numero.positions.length > 1}
                 label={numero.numeroComplet}
-                secondary={numero.positions.length > 1 && `${numero.positions.length} positions`}
+                secondary={numero.positions.length > 1 ? `${numero.positions.length} positions` : null}
                 onEdit={numero.positions.length === 1 && onEnableEditing}
                 onRemove={onRemove}
               />


### PR DESCRIPTION
- Déclare les `props` oubliées dans `propTypes`
- Attribue des valeurs par défaut à toutes les `props` optionnelles.
- Ajoute les `props` oubliées dans les `Hooks` React