### PR TITLE
Corrige les fitBounds intempestifs 

### DIFF
--- a/components/map/hooks/bounds.js
+++ b/components/map/hooks/bounds.js
@@ -5,6 +5,8 @@ import buffer from '@turf/buffer'
 import BalDataContext from '../../../contexts/bal-data'
 import MarkerContext from '../../../contexts/marker'
 
+const BUFFER_RADIUS = 100
+
 function useBounds(commune, voie) {
   const {geojson} = useContext(BalDataContext)
   const {marker, enabled} = useContext(MarkerContext)
@@ -18,7 +20,7 @@ function useBounds(commune, voie) {
       return buffer({
         type: 'Point',
         coordinates: [marker.longitude, marker.latitude]
-      }, 50, {
+      }, BUFFER_RADIUS, {
         units: 'meters'
       })
     }
@@ -34,7 +36,7 @@ function useBounds(commune, voie) {
       }
 
       if (data.features.length === 1) {
-        return buffer(data.features[0], 50, {
+        return buffer(data.features[0], BUFFER_RADIUS, {
           units: 'meters'
         })
       }

--- a/components/map/hooks/bounds.js
+++ b/components/map/hooks/bounds.js
@@ -1,4 +1,4 @@
-import {useMemo, useContext} from 'react'
+import {useState, useMemo, useContext} from 'react'
 import bbox from '@turf/bbox'
 import buffer from '@turf/buffer'
 
@@ -7,6 +7,7 @@ import BalDataContext from '../../../contexts/bal-data'
 const BUFFER_RADIUS = 100
 
 function useBounds(commune, voie) {
+  const [currentVoie, setCurrentVoie] = useState(null)
   const {geojson} = useContext(BalDataContext)
 
   const data = useMemo(() => {
@@ -14,6 +15,11 @@ function useBounds(commune, voie) {
       let data = geojson
 
       if (voie) {
+        if (voie._id === currentVoie) {
+          return false
+        }
+
+        setCurrentVoie(voie._id)
         data = {
           type: 'FeatureCollection',
           features: data.features.filter(feature => feature.properties.idVoie === voie._id)

--- a/components/map/hooks/bounds.js
+++ b/components/map/hooks/bounds.js
@@ -3,28 +3,13 @@ import bbox from '@turf/bbox'
 import buffer from '@turf/buffer'
 
 import BalDataContext from '../../../contexts/bal-data'
-import MarkerContext from '../../../contexts/marker'
 
 const BUFFER_RADIUS = 100
 
 function useBounds(commune, voie) {
   const {geojson} = useContext(BalDataContext)
-  const {marker, enabled} = useContext(MarkerContext)
 
   const data = useMemo(() => {
-    if (enabled && marker) {
-      if (voie) {
-        return false
-      }
-
-      return buffer({
-        type: 'Point',
-        coordinates: [marker.longitude, marker.latitude]
-      }, BUFFER_RADIUS, {
-        units: 'meters'
-      })
-    }
-
     if (geojson) {
       let data = geojson
 
@@ -51,11 +36,7 @@ function useBounds(commune, voie) {
     }
 
     return null
-
-    // We’re depending on `enabled` and not `marker` here so that
-    // we only re-center the map when the marker gets enabled.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [geojson, commune, voie, enabled])
+  }, [geojson, commune, voie])
 
   return useMemo(() => data ? bbox(data) : data, [data])
 }


### PR DESCRIPTION
## fitBounds
- La carte ne recentre plus si la voie est la même afin d'éviter de perturber l'utilisateur après un ajout ou une suppression de numéro.
- La carte ne recentre plus sur le marqueur

## Zoom
- Le rayon du buffer de fitbounds a été réduit afin de ne plus afficher une image dégradée 