### PR TITLE
Désactive l'autocomplétion de chrome sur le formulaire de création de BAL

### DIFF
--- a/pages/new/create-form.js
+++ b/pages/new/create-form.js
@@ -6,6 +6,7 @@ import {Pane, TextInputField, Checkbox, Button} from 'evergreen-ui'
 import {storeBalAccess} from '../../lib/tokens'
 import {createBaseLocale, addCommune, populateCommune} from '../../lib/bal-api'
 
+import useFocus from '../../hooks/focus'
 import {useInput, useCheckboxInput} from '../../hooks/input'
 
 import {CommuneSearchField} from '../../components/commune-search'
@@ -18,6 +19,7 @@ function CreateForm({defaultCommune}) {
   const [email, onEmailChange] = useInput('')
   const [populate, onPopulateChange] = useCheckboxInput(true)
   const [commune, setCommune] = useState(defaultCommune ? defaultCommune.code : null)
+  const focusRef = useFocus()
 
   const onSelect = useCallback(commune => {
     setCommune(commune.code)
@@ -52,6 +54,7 @@ function CreateForm({defaultCommune}) {
     <Pane is='form' margin={16} padding={16} overflowY='scroll' background='tint2' onSubmit={onSubmit}>
       <TextInputField
         required
+        innerRef={focusRef}
         name='nom'
         id='nom'
         value={nom}

--- a/pages/new/create-form.js
+++ b/pages/new/create-form.js
@@ -55,6 +55,7 @@ function CreateForm({defaultCommune}) {
       <TextInputField
         required
         innerRef={focusRef}
+        autocomplete='new-password' // Hack to bypass chrome autocomplete
         name='nom'
         id='nom'
         value={nom}

--- a/pages/new/upload-form.js
+++ b/pages/new/upload-form.js
@@ -104,6 +104,7 @@ function Index() {
             <TextInputField
               required
               innerRef={focusRef}
+              autocomplete='new-password' // Hack to bypass chrome autocomplete
               name='nom'
               id='nom'
               value={nom}


### PR DESCRIPTION
Le navigateur chrome détecte les mots `Nom` et `Adresse` dans le champ texte du formulaire de création de BAL et autocomplète avec l'adresse de l'utilisateur. La propriété `autocomplete='off'` n'étant pas prise en compte par chrome, nous le forçons à laisser le champ vierge grâce à `new-password`