### PR TITLE
Corrige la récupération des BAL de l'utilisateur

### DIFF
--- a/components/user-bases-locales.js
+++ b/components/user-bases-locales.js
@@ -14,10 +14,15 @@ function UserBasesLocales() {
     const balAccess = getBalAccess()
     const getUserBals = async () => {
       const bals = await Promise.all(
-        map(balAccess, (token, id) => getBaseLocale(id, token))
-      )
+        map(balAccess, async (token, id) => {
+          try {
+            return await getBaseLocale(id, token)
+          } catch (error) {
+            console.log(`Impossible de récupérer la bal ${id}`)
+          }
+        }))
 
-      setbals(bals)
+      setbals(bals.filter(bal => Boolean(bal)))
     }
 
     if (balAccess) {


### PR DESCRIPTION
Si une BAL n'existe plus en base alors celle-ci provoque une erreur qui bloque la récupération des autres BAL.