### PR TITLE
Ajouter des commentaires aux numéros

### DIFF
--- a/components/bal/address-editor.js
+++ b/components/bal/address-editor.js
@@ -9,6 +9,8 @@ import {useInput, useCheckboxInput} from '../../hooks/input'
 import useFocus from '../../hooks/focus'
 import useKeyEvent from '../../hooks/key-event'
 
+import Comment from '../comment'
+
 import PositionEditor from './position-editor'
 import VoieSearch from './voie-search'
 
@@ -20,6 +22,7 @@ function CreateAddress({onSubmit, onCancel}) {
   const [numero, onNumeroChange] = useInput('')
   const [selectedVoie, setSelectedVoie] = useState(voie)
   const [suffixe, onSuffixeChange] = useInput('')
+  const [comment, onCommentChange] = useInput('')
   const [type, onTypeChange] = useInput('entrée')
   const [error, setError] = useState()
   const focusRef = useFocus()
@@ -41,6 +44,7 @@ function CreateAddress({onSubmit, onCancel}) {
     } else {
       body.numero = Number(numero)
       body.suffixe = suffixe.length > 0 ? suffixe : null
+      body.comment = comment.length > 0 ? comment : null
     }
 
     body.positions = [
@@ -60,7 +64,7 @@ function CreateAddress({onSubmit, onCancel}) {
       setError(error.message)
       setIsLoading(false)
     }
-  }, [isToponyme, marker, type, numero, suffixe, onSubmit, selectedVoie, disableMarker])
+  }, [isToponyme, marker, type, numero, suffixe, comment, onSubmit, selectedVoie, disableMarker])
 
   const onFormCancel = useCallback(e => {
     e.preventDefault()
@@ -145,6 +149,10 @@ function CreateAddress({onSubmit, onCancel}) {
           type={type}
           onTypeChange={onTypeChange}
         />
+      )}
+
+      {!isToponyme && (
+        <Comment input={comment} onChange={onCommentChange} />
       )}
 
       {error && (

--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -19,7 +19,7 @@ function NumeroEditor({initialValue, onSubmit, onCancel}) {
   const [numero, onNumeroChange] = useInput(initialValue ? initialValue.numero : '')
   const [suffixe, onSuffixeChange] = useInput(initialValue ? initialValue.suffixe : '')
   const [type, onTypeChange] = useInput(position ? position.type : 'entrée')
-  const [comment, onCommentChange] = useInput(initialValue.comment || '')
+  const [comment, onCommentChange] = useInput(initialValue ? initialValue.comment : '')
   const [error, setError] = useState()
   const focusRef = useFocus()
 

--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -8,6 +8,8 @@ import {useInput} from '../../hooks/input'
 import useFocus from '../../hooks/focus'
 import useKeyEvent from '../../hooks/key-event'
 
+import Comment from '../comment'
+
 import PositionEditor from './position-editor'
 
 function NumeroEditor({initialValue, onSubmit, onCancel}) {
@@ -17,6 +19,7 @@ function NumeroEditor({initialValue, onSubmit, onCancel}) {
   const [numero, onNumeroChange] = useInput(initialValue ? initialValue.numero : '')
   const [suffixe, onSuffixeChange] = useInput(initialValue ? initialValue.suffixe : '')
   const [type, onTypeChange] = useInput(position ? position.type : 'entrée')
+  const [comment, onCommentChange] = useInput(initialValue.comment || '')
   const [error, setError] = useState()
   const focusRef = useFocus()
 
@@ -36,6 +39,7 @@ function NumeroEditor({initialValue, onSubmit, onCancel}) {
     }
 
     body.suffixe = suffixe.length > 0 ? suffixe : null
+    body.comment = comment.length > 0 ? comment : null
 
     if (marker) {
       body.positions = [
@@ -56,7 +60,7 @@ function NumeroEditor({initialValue, onSubmit, onCancel}) {
       setError(error.message)
       setIsLoading(false)
     }
-  }, [numero, suffixe, marker, type, onSubmit, disableMarker])
+  }, [numero, suffixe, comment, marker, type, onSubmit, disableMarker])
 
   const onFormCancel = useCallback(e => {
     e.preventDefault()
@@ -139,6 +143,8 @@ function NumeroEditor({initialValue, onSubmit, onCancel}) {
           onTypeChange={onTypeChange}
         />
       )}
+
+      <Comment input={comment} onChange={onCommentChange} />
 
       {error && (
         <Alert marginBottom={16} intent='danger' title='Erreur'>

--- a/components/comment.js
+++ b/components/comment.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import {Pane, Textarea, Label} from 'evergreen-ui'
 
-const Comment = ({input, onChange}) => {
+const Comment = ({input, limit, onChange}) => {
   return (
     <Pane>
       <Label marginBottom={4} display='block'>
@@ -11,7 +11,7 @@ const Comment = ({input, onChange}) => {
       <Textarea
         placeholder='Note…'
         value={input}
-        onChange={onChange}
+        onChange={input.length < limit ? onChange : () => {}}
       />
     </Pane>
   )
@@ -19,11 +19,13 @@ const Comment = ({input, onChange}) => {
 
 Comment.propTypes = {
   input: PropTypes.string,
+  limit: PropTypes.number,
   onChange: PropTypes.func.isRequired
 }
 
 Comment.defaultProps = {
-  input: ''
+  input: '',
+  limit: 5000
 }
 
 export default Comment

--- a/components/comment.js
+++ b/components/comment.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {Pane, Textarea, Label} from 'evergreen-ui'
+
+const Comment = ({input, onChange}) => {
+  return (
+    <Pane>
+      <Label marginBottom={4} display='block'>
+        Commentaire
+      </Label>
+      <Textarea
+        placeholder='Note…'
+        value={input}
+        onChange={onChange}
+      />
+    </Pane>
+  )
+}
+
+Comment.propTypes = {
+  input: PropTypes.string,
+  onChange: PropTypes.func.isRequired
+}
+
+Comment.defaultProps = {
+  input: ''
+}
+
+export default Comment

--- a/components/help/help-tabs/numeros.js
+++ b/components/help/help-tabs/numeros.js
@@ -148,6 +148,34 @@ const Numeros = () => {
           </SubTuto>
         </Tuto>
 
+        <Tuto title='Ajouter une note ou un commentaire'>
+          {before}
+
+          <OrderedList margin={8}>
+            <ListItem>
+                Cliquez sur le bouton <Button background='tint1' iconBefore='more' appearance='minimal' /> se situant à droite du numéro
+            </ListItem>
+            <ListItem>
+              <Pane display='flex' alignItems='center'>
+                  Dans le menu qui vient d’apparaître, choisissez
+                <Menu.Item background='tint1' marginLeft={8} icon='edit'>
+                    Modifier
+                </Menu.Item>
+              </Pane>
+            </ListItem>
+            <ListItem>
+                Remplissez le champ de texte <Strong size={500}>Commentaire</Strong> afin de laisser une note concernant le numéro
+            </ListItem>
+            <ListItem>
+              Pour enregistrer votre commentaire, cliquez sur le bouton <Button marginX={4} appearance='primary' intent='success'>Modifier</Button>
+            </ListItem>
+          </OrderedList>
+
+          <Paragraph>
+            Vous remarquerez un <Icon icon='comment' /> sur la ligne du numéro. Le survolez vous permettra de faire apparaitre le commentaire.
+          </Paragraph>
+        </Tuto>
+
         <Problems>
           <Tuto title='Je ne trouve pas de voie lorsque j’ajoute un numéro depuis la carte'>
             <Paragraph marginTop='default'>

--- a/components/table-row.js
+++ b/components/table-row.js
@@ -1,10 +1,10 @@
 import React, {useState, useContext, useCallback} from 'react'
 import PropTypes from 'prop-types'
-import {Table, Popover, Menu, Position, IconButton, toaster, Icon} from 'evergreen-ui'
+import {Table, Popover, Menu, Position, IconButton, toaster, Tooltip, Icon} from 'evergreen-ui'
 
 import TokenContext from '../contexts/token'
 
-const TableRow = React.memo(({id, code, label, secondary, isSelectable, onSelect, onEdit, onRemove}) => {
+const TableRow = React.memo(({id, code, label, comment, secondary, isSelectable, onSelect, onEdit, onRemove}) => {
   const [hovered, setHovered] = useState(false)
   const {token} = useContext(TokenContext)
 
@@ -63,6 +63,16 @@ const TableRow = React.memo(({id, code, label, secondary, isSelectable, onSelect
           {secondary}
         </Table.TextCell>
       )}
+      {comment && (
+        <Table.Cell>
+          <Tooltip
+            content={comment}
+            position={Position.BOTTOM_RIGHT}
+          >
+            <Icon icon='comment' color='muted' />
+          </Tooltip>
+        </Table.Cell>
+      )}
       {token && (onEdit || onRemove) && (
         <Table.TextCell flex='0 1 1'>
           <Popover
@@ -101,6 +111,7 @@ TableRow.propTypes = {
   id: PropTypes.string.isRequired,
   code: PropTypes.string,
   label: PropTypes.string.isRequired,
+  comment: PropTypes.string,
   secondary: PropTypes.string,
   isSelectable: PropTypes.bool,
   onSelect: PropTypes.func.isRequired,
@@ -110,6 +121,7 @@ TableRow.propTypes = {
 
 TableRow.defaultProps = {
   code: null,
+  comment: null,
   secondary: null,
   isSelectable: true,
   onEdit: null

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -70,10 +70,11 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
     setEditingId(idNumero)
   }, [setEditingId])
 
-  const onEdit = useCallback(async ({numero, suffixe, positions}) => {
+  const onEdit = useCallback(async ({numero, suffixe, comment, positions}) => {
     await editNumero(editingId, {
       numero,
       suffixe,
+      comment,
       positions
     }, token)
 

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -38,10 +38,11 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
     ]
   })
 
-  const onAdd = useCallback(async ({numero, suffixe, positions}) => {
+  const onAdd = useCallback(async ({numero, suffixe, comment, positions}) => {
     await addNumero(voie._id, {
       numero,
       suffixe,
+      comment,
       positions
     }, token)
 

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -200,6 +200,7 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
               <TableRow
                 key={numero._id}
                 id={numero._id}
+                comment={numero.comment}
                 isSelectable={!isAdding && !editingId && numero.positions.length > 1}
                 label={numero.numeroComplet}
                 secondary={numero.positions.length > 1 ? `${numero.positions.length} positions` : null}


### PR DESCRIPTION
Offre la possibilité d'ajouter des commentaires dans l'édition des numéros.

Un numéro commenté se distingue par un ![Capture d’écran 2019-06-21 à 11 21 52](https://user-images.githubusercontent.com/7040549/59912676-cbbf1600-9416-11e9-82b7-4be5f810b56d.png)

Il est possible de voir le commentaire en survolant cet icon.

Le champ de texte prévu pour les commentaires est limité à 5000 caractères.
 
![Jun-21-2019 11-17-13](https://user-images.githubusercontent.com/7040549/59912384-3a4fa400-9416-11e9-8fcf-e2b60e6e53c8.gif)

⚠️ Cette PR est dépendante de https://github.com/etalab/api-bal/pull/70 qui met à jour l'API
