### PR TITLE
Ne plus afficher le bouton "supprimer" pour une BAL publiée

### DIFF
--- a/components/bases-locales-list.js
+++ b/components/bases-locales-list.js
@@ -100,7 +100,7 @@ function BasesLocalesList({basesLocales, updateBasesLocales}) {
                       <Badge color='neutral'>Brouillon</Badge>
                     )}</Table.Cell>
                   <Table.TextCell flexBasis={100} flexGrow={0}>
-                    <IconButton icon='trash' intent='danger' onClick={e => handleRemove(e, bal._id)} />
+                    {!bal.published && <IconButton icon='trash' intent='danger' onClick={e => handleRemove(e, bal._id)} />}
                   </Table.TextCell>
                 </Table.Row>
               ))}


### PR DESCRIPTION
Lorsque qu'un BAL est publiée, le bouton "supprimer" ne sera plus afficher afin d'éviter une suppression par erreur.

<img width="916" alt="Capture d’écran 2019-08-29 à 15 55 45" src="https://user-images.githubusercontent.com/7040549/63946880-2fe50280-ca76-11e9-8c09-d4a521359a00.png">
