### PR TITLE
Nouveau statut "Prête à être publiée"

### DIFF
--- a/components/bases-locales-list/base-locale-row.js
+++ b/components/bases-locales-list/base-locale-row.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {Table, Badge, IconButton} from 'evergreen-ui'
+
+function BaseLocaleRow({baseLocale, editable, onSelect, onRemove}) {
+  const {_id, nom, communes, published} = baseLocale
+
+  return (
+    <Table.Row key={_id} isSelectable onSelect={onSelect}>
+      <Table.TextCell flexGrow={2}>{nom}</Table.TextCell>
+      <Table.TextCell>
+        {communes.length < 2 ? `${communes.length} commune` : `${communes.length} communes`}
+      </Table.TextCell>
+      <Table.Cell>
+        {published ? (
+          <Badge color='green'>Publiée</Badge>
+        ) : (
+          <Badge color='neutral'>Brouillon</Badge>
+        )}</Table.Cell>
+      <Table.TextCell flexBasis={100} flexGrow={0}>
+        {!published && editable && <IconButton icon='trash' intent='danger' onClick={onRemove} />}
+      </Table.TextCell>
+    </Table.Row>
+  )
+}
+
+BaseLocaleRow.defaultProps = {
+  editable: false,
+  onRemove: null
+}
+
+BaseLocaleRow.propTypes = {
+  baseLocale: PropTypes.shape({
+    _id: PropTypes.string.isRequired,
+    nom: PropTypes.string.isRequired,
+    communes: PropTypes.array.isRequired,
+    published: PropTypes.bool
+  }).isRequired,
+  editable: PropTypes.bool,
+  onSelect: PropTypes.func.isRequired,
+  onRemove: PropTypes.func
+
+}
+
+export default BaseLocaleRow

--- a/components/bases-locales-list/base-locale-row.js
+++ b/components/bases-locales-list/base-locale-row.js
@@ -2,8 +2,20 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import {Table, Badge, IconButton} from 'evergreen-ui'
 
+function getBadge(status) {
+  switch (status) {
+    case 'published':
+      return {color: 'green', label: 'Publiée'}
+    case 'ready-to-publish':
+      return {color: 'blue', label: 'Prête à être publiée'}
+    default:
+      return {color: 'neutral', label: 'Brouillon'}
+  }
+}
+
 function BaseLocaleRow({baseLocale, editable, onSelect, onRemove}) {
-  const {_id, nom, communes, published} = baseLocale
+  const {_id, nom, communes, status} = baseLocale
+  const badge = getBadge(status)
 
   return (
     <Table.Row key={_id} isSelectable onSelect={onSelect}>
@@ -12,13 +24,12 @@ function BaseLocaleRow({baseLocale, editable, onSelect, onRemove}) {
         {communes.length < 2 ? `${communes.length} commune` : `${communes.length} communes`}
       </Table.TextCell>
       <Table.Cell>
-        {published ? (
-          <Badge color='green'>Publiée</Badge>
-        ) : (
-          <Badge color='neutral'>Brouillon</Badge>
-        )}</Table.Cell>
+        <Badge color={badge.color}>{badge.label}</Badge>
+      </Table.Cell>
       <Table.TextCell flexBasis={100} flexGrow={0}>
-        {!published && editable && <IconButton icon='trash' intent='danger' onClick={onRemove} />}
+        {status === 'draft' && editable && (
+          <IconButton icon='trash' intent='danger' onClick={onRemove} />
+        )}
       </Table.TextCell>
     </Table.Row>
   )
@@ -34,7 +45,9 @@ BaseLocaleRow.propTypes = {
     _id: PropTypes.string.isRequired,
     nom: PropTypes.string.isRequired,
     communes: PropTypes.array.isRequired,
-    published: PropTypes.bool
+    status: PropTypes.oneOf([
+      'draft', 'ready-to-publish', 'published'
+    ])
   }).isRequired,
   editable: PropTypes.bool,
   onSelect: PropTypes.func.isRequired,

--- a/components/bases-locales-list/index.js
+++ b/components/bases-locales-list/index.js
@@ -1,16 +1,17 @@
 import React, {useState, useCallback} from 'react'
 import PropTypes from 'prop-types'
 import Router from 'next/router'
-import {Pane, Table, Paragraph, Badge, IconButton} from 'evergreen-ui'
+import {Pane, Table, Paragraph} from 'evergreen-ui'
 
-import {getBalAccess, getBalToken, removeBalAccess} from '../lib/tokens'
+import {getBalAccess, getBalToken, removeBalAccess} from '../../lib/tokens'
 
-import useFuse from '../hooks/fuse'
-import useError from '../hooks/error'
+import useFuse from '../../hooks/fuse'
+import useError from '../../hooks/error'
 
-import {listBasesLocales, removeBaseLocale} from '../lib/bal-api'
+import {listBasesLocales, removeBaseLocale} from '../../lib/bal-api'
 
-import DeleteWarning from './delete-warning'
+import DeleteWarning from '../delete-warning'
+import BaseLocaleRow from './base-locale-row'
 
 function BasesLocalesList({basesLocales, updateBasesLocales}) {
   const [toRemove, setToRemove] = useState(null)
@@ -34,11 +35,11 @@ function BasesLocalesList({basesLocales, updateBasesLocales}) {
       'commune'
     ]
   })
-  
+
   // Actuellement cette variable est inférée par la présence ou non de cette fonction, injectée plus haut.
   // La page public est la page /all
   // À améliorer !!
-  const isPublicPage = !Boolean(updateBasesLocales)
+  const isPublicPage = !updateBasesLocales
 
   const onRemove = useCallback(async () => {
     try {
@@ -93,23 +94,13 @@ function BasesLocalesList({basesLocales, updateBasesLocales}) {
             )}
             <Table.Body background='tint1'>
               {filtered.map(bal => (
-                <Table.Row key={bal._id} isSelectable onSelect={() => onBalSelect(bal)}>
-                  <Table.TextCell flexGrow={2}>{bal.nom}</Table.TextCell>
-                  <Table.TextCell>
-                    {bal.communes.length < 2 ? `${bal.communes.length} commune` : `${bal.communes.length} communes`}
-                  </Table.TextCell>
-                  <Table.Cell>
-                    {bal.published ? (
-                      <Badge color='green'>Publiée</Badge>
-                    ) : (
-                      <Badge color='neutral'>Brouillon</Badge>
-                    )}</Table.Cell>
-                  <Table.TextCell flexBasis={100} flexGrow={0}>
-                    {!bal.published && !isPublicPage && (
-                      <IconButton icon='trash' intent='danger' onClick={e => handleRemove(e, bal._id)} />
-                    )}
-                  </Table.TextCell>
-                </Table.Row>
+                <BaseLocaleRow
+                  key={bal._id}
+                  baseLocale={bal}
+                  editable={!isPublicPage}
+                  onSelect={() => onBalSelect(bal)}
+                  onRemove={e => handleRemove(e, bal._id)}
+                />
               ))}
             </Table.Body>
           </Table>

--- a/components/header/publication.js
+++ b/components/header/publication.js
@@ -1,0 +1,81 @@
+import React, {useMemo} from 'react'
+import PropTypes from 'prop-types'
+import {css} from 'glamor'
+
+import {Button, Menu, Popover, Tooltip, Position} from 'evergreen-ui'
+
+const Publication = ({token, status, onChangeStatus, onPublish}) => {
+  const editTip = useMemo(() => css({
+    '@media (max-width: 700px)': {
+      marginLeft: -10,
+
+      '& > span': {
+        display: 'none'
+      }
+    }
+  }), [])
+
+  if (!token) {
+    return (
+      <Tooltip
+        content='Vous n’êtes pas identifié comme administrateur de cette base adresse locale, vous ne pouvez donc pas l’éditer.'
+        position={Position.BOTTOM_RIGHT}
+      >
+        <Button height={24} marginRight={8} appearance='primary' intent='danger' iconBefore='edit'>
+          <div className={editTip}><span>Édition impossible</span></div>
+        </Button>
+      </Tooltip>
+    )
+  }
+
+  return (
+    <>
+      {status === 'ready-to-publish' ? (
+        <div>
+          <Popover
+            position={Position.BOTTOM_RIGHT}
+            content={
+              <Menu>
+                <Menu.Group>
+                  <Menu.Item icon='upload' onClick={onPublish}>
+                    Publier
+                  </Menu.Item>
+                  <Menu.Item icon='edit' onClick={onChangeStatus}>
+                    Revenir au brouillon
+                  </Menu.Item>
+                </Menu.Group>
+              </Menu>
+            }
+          >
+            <Button
+              intent='info'
+              appearance='primary'
+              marginRight={8}
+              height={24}
+              iconAfter='caret-down'
+            >
+              Publication
+            </Button>
+          </Popover>
+        </div>
+      ) : (
+        <Button marginRight={8} height={24} appearance='primary' onClick={onChangeStatus}>
+          {status === 'published' ? 'Mettre à jour' : 'Prêt à être publié' }
+        </Button>
+      )}
+    </>
+  )
+}
+
+Publication.defaultProps = {
+  token: null
+}
+
+Publication.propTypes = {
+  token: PropTypes.string,
+  status: PropTypes.string.isRequired,
+  onChangeStatus: PropTypes.func.isRequired,
+  onPublish: PropTypes.func.isRequired
+}
+
+export default Publication


### PR DESCRIPTION
Cette PR ajoute la gestion du nouveau statut "Prête à être publiée".

Il permet plusieurs choses:
- L'utilisateur peut la reconnaitre facilement dans sa liste de BAL
- Une BAL avec ce statut ne peut plus être supprimée
- Il nous permet de reconnaitre les BAL qui serait prête à être publiée et ainsi de contacter l'utilisateur afin de savoir pourquoi il ne l'a pas encore publié

Le header permet de changer le statut d'une BAL à la demande si celle-ci n'est pas publiée.

## Démo
![bal-status](https://user-images.githubusercontent.com/7040549/64348930-55ce5200-cff6-11e9-8057-ce6b631a92e4.gif)

⚠️[Attendre la mise à jour de l'api-bal](https://github.com/etalab/api-bal/pull/87)

Fix #87 