### PR TITLE
Modification comportement barre latérale

### DIFF
--- a/components/bal/address-editor.js
+++ b/components/bal/address-editor.js
@@ -1,6 +1,6 @@
 import React, {useState, useMemo, useCallback, useContext, useEffect} from 'react'
 import PropTypes from 'prop-types'
-import {Pane, Heading, TextInput, Button, IconButton, Alert, Checkbox} from 'evergreen-ui'
+import {Pane, Heading, TextInput, Button, Alert, Checkbox} from 'evergreen-ui'
 
 import MarkerContext from '../../contexts/marker'
 import BalDataContext from '../../contexts/bal-data'
@@ -161,19 +161,21 @@ function CreateAddress({onSubmit, onCancel}) {
         </Alert>
       )}
 
-      <Button isLoading={isLoading} type='submit' appearance='primary' intent='success'>
+      <Button isLoading={isLoading} type='submit' appearance='primary' intent='success' marginTop={16}>
         {submitLabel}
       </Button>
 
       {onCancel && (
-        <IconButton
+        <Button
           disabled={isLoading}
-          icon='undo'
           appearance='minimal'
           marginLeft={8}
+          marginTop={16}
           display='inline-flex'
           onClick={onFormCancel}
-        />
+        >
+          Annuler
+        </Button>
       )}
     </Pane>
   )

--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -1,6 +1,6 @@
 import React, {useState, useMemo, useCallback, useContext, useEffect} from 'react'
 import PropTypes from 'prop-types'
-import {Pane, TextInput, Button, IconButton, Alert} from 'evergreen-ui'
+import {Pane, TextInput, Button, Alert} from 'evergreen-ui'
 
 import MarkerContext from '../../contexts/marker'
 

--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -157,14 +157,14 @@ function NumeroEditor({initialValue, onSubmit, onCancel}) {
       </Button>
 
       {onCancel && (
-        <IconButton
+        <Button
           disabled={isLoading}
-          icon='undo'
-          appearance='minimal'
           marginLeft={8}
           display='inline-flex'
           onClick={onFormCancel}
-        />
+        >
+          Annuler
+        </Button>
       )}
     </Pane>
   )

--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -152,14 +152,16 @@ function NumeroEditor({initialValue, onSubmit, onCancel}) {
         </Alert>
       )}
 
-      <Button isLoading={isLoading} type='submit' appearance='primary' intent='success'>
+      <Button isLoading={isLoading} type='submit' appearance='primary' intent='success' marginTop={16}>
         {submitLabel}
       </Button>
 
       {onCancel && (
         <Button
           disabled={isLoading}
+          appearance='minimal'
           marginLeft={8}
+          marginTop={16}
           display='inline-flex'
           onClick={onFormCancel}
         >

--- a/components/bal/voie-editor.js
+++ b/components/bal/voie-editor.js
@@ -10,7 +10,7 @@ import useKeyEvent from '../../hooks/key-event'
 
 import PositionEditor from './position-editor'
 
-function VoieEditor({initialValue, onSubmit, onCancel}) {
+function VoieEditor({initialValue, onSubmit, onCancel, handleMouseEnter}) {
   const position = initialValue ? initialValue.positions[0] : null
 
   const [isLoading, setIsLoading] = useState(false)
@@ -88,7 +88,7 @@ function VoieEditor({initialValue, onSubmit, onCancel}) {
   }, [enabled, initialValue, disableMarker, enableMarker, isToponyme, position])
 
   return (
-    <Pane is='form' onSubmit={onFormSubmit}>
+    <Pane is='form' onSubmit={onFormSubmit} onMouseEnter={handleMouseEnter}>
       <TextInput
         required
         display='block'
@@ -138,6 +138,7 @@ function VoieEditor({initialValue, onSubmit, onCancel}) {
       {onCancel && (
         <Button
           disabled={isLoading}
+          appearance='minimal'
           marginLeft={8}
           display='inline-flex'
           onClick={onFormCancel}

--- a/components/bal/voie-editor.js
+++ b/components/bal/voie-editor.js
@@ -1,6 +1,6 @@
 import React, {useState, useMemo, useContext, useCallback, useEffect} from 'react'
 import PropTypes from 'prop-types'
-import {Pane, TextInput, Button, Checkbox, IconButton, Alert} from 'evergreen-ui'
+import {Pane, TextInput, Button, Checkbox, Alert} from 'evergreen-ui'
 
 import MarkerContext from '../../contexts/marker'
 
@@ -136,14 +136,14 @@ function VoieEditor({initialValue, onSubmit, onCancel}) {
       </Button>
 
       {onCancel && (
-        <IconButton
+        <Button
           disabled={isLoading}
-          icon='undo'
-          appearance='minimal'
           marginLeft={8}
           display='inline-flex'
           onClick={onFormCancel}
-        />
+        >
+          Annuler
+        </Button>
       )}
     </Pane>
   )

--- a/components/bal/voie-editor.js
+++ b/components/bal/voie-editor.js
@@ -10,7 +10,7 @@ import useKeyEvent from '../../hooks/key-event'
 
 import PositionEditor from './position-editor'
 
-function VoieEditor({initialValue, onSubmit, onCancel, handleMouseEnter}) {
+function VoieEditor({initialValue, onSubmit, onCancel}) {
   const position = initialValue ? initialValue.positions[0] : null
 
   const [isLoading, setIsLoading] = useState(false)
@@ -88,7 +88,7 @@ function VoieEditor({initialValue, onSubmit, onCancel, handleMouseEnter}) {
   }, [enabled, initialValue, disableMarker, enableMarker, isToponyme, position])
 
   return (
-    <Pane is='form' onSubmit={onFormSubmit} onMouseEnter={handleMouseEnter}>
+    <Pane is='form' onSubmit={onFormSubmit}>
       <TextInput
         required
         display='block'

--- a/components/comment.js
+++ b/components/comment.js
@@ -9,6 +9,7 @@ const Comment = ({input, limit, onChange}) => {
         Commentaire
       </Label>
       <Textarea
+        marginBottom={16}
         placeholder='Note…'
         value={input}
         onChange={input.length < limit ? onChange : () => {}}

--- a/components/comment.js
+++ b/components/comment.js
@@ -9,7 +9,6 @@ const Comment = ({input, limit, onChange}) => {
         Commentaire
       </Label>
       <Textarea
-        marginBottom={16}
         placeholder='Note…'
         value={input}
         onChange={input.length < limit ? onChange : () => {}}

--- a/components/layout/sidebar.js
+++ b/components/layout/sidebar.js
@@ -7,13 +7,13 @@ import BalDataContext from '../../contexts/bal-data'
 
 function Sidebar({isHidden, top, size, onToggle, ...props}) {
   const {innerWidth} = useWindowSize()
-  const {editingId} = useContext(BalDataContext)
+  const {editingId, setEditingId} = useContext(BalDataContext)
 
   useEffect(() => {
     if (editingId && isHidden) {
       onToggle()
     }
-  }, [editingId, isHidden])
+  }, [editingId, isHidden, onToggle])
 
   return (
     <Pane
@@ -40,7 +40,7 @@ function Sidebar({isHidden, top, size, onToggle, ...props}) {
             paddingX={8}
             elevation={0}
             borderRadius={0}
-            onClick={() => onToggle(editingId)}
+            onClick={() => editingId && !isHidden ? setEditingId(false) : onToggle(editingId)}
           >
             <Icon
               icon={isHidden ? 'chevron-right' : editingId ? 'cross' : 'chevron-left'}

--- a/components/layout/sidebar.js
+++ b/components/layout/sidebar.js
@@ -1,11 +1,19 @@
-import React from 'react'
+import React, {useContext, useEffect} from 'react'
 import PropTypes from 'prop-types'
 import {Pane, Button, Icon} from 'evergreen-ui'
 
 import useWindowSize from '../../hooks/window-size'
+import BalDataContext from '../../contexts/bal-data'
 
 function Sidebar({isHidden, top, size, onToggle, ...props}) {
   const {innerWidth} = useWindowSize()
+  const {editingId} = useContext(BalDataContext)
+
+  useEffect(() => {
+    if (editingId && isHidden) {
+      onToggle()
+    }
+  }, [editingId, isHidden])
 
   return (
     <Pane
@@ -32,10 +40,10 @@ function Sidebar({isHidden, top, size, onToggle, ...props}) {
             paddingX={8}
             elevation={0}
             borderRadius={0}
-            onClick={onToggle}
+            onClick={() => onToggle(editingId)}
           >
             <Icon
-              icon={isHidden ? 'chevron-right' : 'chevron-left'}
+              icon={isHidden ? 'chevron-right' : editingId ? 'cross' : 'chevron-left'}
             />
           </Button>
         </Pane>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -38,9 +38,9 @@ function App({error, Component, pageProps, query}) {
   const {layout, ...otherPageProps} = pageProps
   const Wrapper = layoutMap[layout] || Fullscreen
 
-  // Open sidebar when numero is edited:
   const onToggle = useCallback(isEditing => {
     if (isEditing && isHidden) {
+    // Force opening sidebar when numero is edited:
       setIsHidden(false)
     } else {
       setIsHidden(isHidden => !isHidden)

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -38,13 +38,14 @@ function App({error, Component, pageProps, query}) {
   const {layout, ...otherPageProps} = pageProps
   const Wrapper = layoutMap[layout] || Fullscreen
 
+  // Open sidebar when numero is edited:
   const onToggle = useCallback(isEditing => {
-    if (isEditing === null) {
-      setIsHidden(isHidden => !isHidden)
-    } else {
+    if (isEditing && isHidden) {
       setIsHidden(false)
+    } else {
+      setIsHidden(isHidden => !isHidden)
     }
-  }, [])
+  }, [isHidden])
 
   const leftOffset = useMemo(() => {
     if (layout === 'sidebar' && !isHidden) {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -35,12 +35,15 @@ function App({error, Component, pageProps, query}) {
   const {innerWidth} = useWindowSize()
   const [isShown, setIsShown] = useState(false)
   const [isHidden, setIsHidden] = useState(false)
-
   const {layout, ...otherPageProps} = pageProps
   const Wrapper = layoutMap[layout] || Fullscreen
 
-  const onToggle = useCallback(() => {
-    setIsHidden(isHidden => !isHidden)
+  const onToggle = useCallback(isEditing => {
+    if (isEditing === null) {
+      setIsHidden(isHidden => !isHidden)
+    } else {
+      setIsHidden(false)
+    }
   }, [])
 
   const leftOffset = useMemo(() => {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -39,8 +39,7 @@ function App({error, Component, pageProps, query}) {
   const Wrapper = layoutMap[layout] || Fullscreen
 
   const onToggle = useCallback(isEditing => {
-    if (isEditing && isHidden) {
-    // Force opening sidebar when numero is edited:
+    if (isEditing && isHidden) { // Force opening sidebar when numero is edited:
       setIsHidden(false)
     } else {
       setIsHidden(isHidden => !isHidden)

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -132,7 +132,10 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
         ) : (
           <Heading
             style={{cursor: hovered ? 'text' : 'default'}}
-            onClick={() => setEdited(true)}
+            onClick={() => {
+              setEdited(true)
+              setHovered(false)
+            }}
             onMouseEnter={() => setHovered(true)}
             onMouseLeave={() => setHovered(false)}
           >

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -105,7 +105,6 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
   useEffect(() => {
     if (editingId) {
       setEdited(false)
-      setHovered(false)
     }
   }, [editingId])
 
@@ -126,6 +125,7 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
         {isEdited ? (
           <VoieEditor
             initialValue={{...voie, nom: voieName}}
+            handleMouseEnter={() => setHovered(false)}
             onSubmit={onEditVoie}
             onCancel={() => setEdited(false)}
           />
@@ -204,7 +204,7 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
               </Table.Row>
             )}
             {editingId ? (
-              <Table.Row key={editedNumero._id} height='auto'>
+              <Table.Row height='auto'>
                 <Table.Cell display='block' paddingY={12} background='tint1'>
                   <NumeroEditor
                     initialValue={editedNumero}

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -102,6 +102,19 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
     }
   }, [voie._id, voies])
 
+  useEffect(() => {
+    if (editingId) {
+      setEdited(false)
+      setHovered(false)
+    }
+  }, [editingId])
+
+  useEffect(() => {
+    if (isEdited) {
+      setEditingId(null)
+    }
+  }, [isEdited, setEditingId])
+
   return (
     <>
       <Pane

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -38,6 +38,8 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
     ]
   })
 
+  const editedNumero = filtered.find(numero => numero._id === editingId)
+
   const onAdd = useCallback(async ({numero, suffixe, comment, positions}) => {
     await addNumero(voie._id, {
       numero,
@@ -188,28 +190,31 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
                 </Table.TextCell>
               </Table.Row>
             )}
-            {filtered.map(numero => numero._id === editingId ? (
-              <Table.Row key={numero._id} height='auto'>
+            {editingId ? (
+              <Table.Row key={editedNumero._id} height='auto'>
                 <Table.Cell display='block' paddingY={12} background='tint1'>
                   <NumeroEditor
-                    initialValue={numero}
+                    initialValue={editedNumero}
                     onSubmit={onEdit}
                     onCancel={onCancel}
                   />
                 </Table.Cell>
               </Table.Row>
             ) : (
-              <TableRow
-                key={numero._id}
-                id={numero._id}
-                comment={numero.comment}
-                isSelectable={!isAdding && !editingId && numero.positions.length > 1}
-                label={numero.numeroComplet}
-                secondary={numero.positions.length > 1 ? `${numero.positions.length} positions` : null}
-                onEdit={onEnableEditing}
-                onRemove={onRemove}
-              />
-            ))}
+              filtered.map(numero => (
+                <TableRow
+                  {...numero}
+                  key={numero._id}
+                  id={numero._id}
+                  comment={numero.comment}
+                  isSelectable={!isAdding && !editingId && numero.positions.length > 1}
+                  label={numero.numeroComplet}
+                  secondary={numero.positions.length > 1 ? `${numero.positions.length} positions` : null}
+                  onEdit={onEnableEditing}
+                  onRemove={onRemove}
+                />
+              ))
+            )}
           </Table>
         ) : (
           <Pane padding={16}>

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -125,7 +125,6 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
         {isEdited ? (
           <VoieEditor
             initialValue={{...voie, nom: voieName}}
-            handleMouseEnter={() => setHovered(false)}
             onSubmit={onEditVoie}
             onCancel={() => setEdited(false)}
           />


### PR DESCRIPTION
- Ouverture de la barre latérale lorsque le numéro est édité
- Lors de l'édition d'un numéro, les autres numéros sont cachés
- Transformation de l'icône "annuler" en bouton :
![Capture d’écran 2019-11-14 à 16 46 22](https://user-images.githubusercontent.com/56537238/69053659-2f6f5e80-0a0a-11ea-8b44-1200d1a50e2d.png)
- L'ouverture de l'éditeur de voie ferme l'éditeur de numéro et vice-versa

