### PR TITLE
Remplace la page /settings par un menu latéral

### DIFF
--- a/components/header/index.js
+++ b/components/header/index.js
@@ -9,6 +9,7 @@ import {getBaseLocaleCsvUrl, updateBaseLocale} from '../../lib/bal-api'
 
 import TokenContext from '../../contexts/token'
 import HelpContext from '../../contexts/help'
+import SettingsContext from '../../contexts/settings'
 
 import useError from '../../hooks/error'
 import useWindowSize from '../../hooks/window-size'
@@ -22,10 +23,11 @@ const ADRESSE_URL = publicRuntimeConfig.ADRESSE_URL || 'https://adresse.data.gou
 
 const Header = React.memo(({baseLocale, commune, voie, layout, isSidebarHidden, refreshBaseLocale, onToggle}) => {
   const {showHelp, setShowHelp} = useContext(HelpContext)
-  const [setError] = useError(null)
-
-  const {innerWidth} = useWindowSize()
+  const {showSettings, setShowSettings} = useContext(SettingsContext)
   const {token} = useContext(TokenContext)
+
+  const [setError] = useError(null)
+  const {innerWidth} = useWindowSize()
 
   const csvUrl = getBaseLocaleCsvUrl(baseLocale._id)
 
@@ -118,11 +120,9 @@ const Header = React.memo(({baseLocale, commune, voie, layout, isSidebarHidden, 
                 <>
                   <Menu.Divider />
                   <Menu.Group>
-                    <NextLink href={`/bal/settings?balId=${baseLocale._id}`} as={`/bal/${baseLocale._id}/settings`}>
-                      <Menu.Item icon='cog' is='a' href={`/bal/${baseLocale._id}/settings`} color='inherit' textDecoration='none'>
-                        Paramètres
-                      </Menu.Item>
-                    </NextLink>
+                    <Menu.Item icon='cog' onSelect={() => setShowSettings(!showSettings)}>
+                      Paramètres
+                    </Menu.Item>
                   </Menu.Group>
                 </>
               )}

--- a/components/header/index.js
+++ b/components/header/index.js
@@ -7,6 +7,7 @@ import {Pane, Popover, Menu, IconButton, Position} from 'evergreen-ui'
 
 import {getBaseLocaleCsvUrl, updateBaseLocale} from '../../lib/bal-api'
 
+import BalDataContext from '../../contexts/bal-data'
 import TokenContext from '../../contexts/token'
 import HelpContext from '../../contexts/help'
 import SettingsContext from '../../contexts/settings'
@@ -21,7 +22,8 @@ import Publication from './publication'
 const {publicRuntimeConfig} = getConfig()
 const ADRESSE_URL = publicRuntimeConfig.ADRESSE_URL || 'https://adresse.data.gouv.fr'
 
-const Header = React.memo(({baseLocale, commune, voie, layout, isSidebarHidden, refreshBaseLocale, onToggle}) => {
+const Header = React.memo(({commune, voie, layout, isSidebarHidden, onToggle}) => {
+  const {baseLocale, reloadBaseLocale} = useContext(BalDataContext)
   const {showHelp, setShowHelp} = useContext(HelpContext)
   const {showSettings, setShowSettings} = useContext(SettingsContext)
   const {token} = useContext(TokenContext)
@@ -36,7 +38,7 @@ const Header = React.memo(({baseLocale, commune, voie, layout, isSidebarHidden, 
       const newStatus = baseLocale.status === 'draft' ? 'ready-to-publish' : 'draft'
       await updateBaseLocale(baseLocale._id, {status: newStatus}, token)
 
-      refreshBaseLocale()
+      await reloadBaseLocale()
     } catch (error) {
       setError(error.message)
     }
@@ -141,12 +143,10 @@ const Header = React.memo(({baseLocale, commune, voie, layout, isSidebarHidden, 
 })
 
 Header.propTypes = {
-  baseLocale: PropTypes.object.isRequired,
   commune: PropTypes.object,
   voie: PropTypes.object,
   layout: PropTypes.oneOf(['fullscreen', 'sidebar']).isRequired,
   isSidebarHidden: PropTypes.bool,
-  refreshBaseLocale: PropTypes.func.isRequired,
   onToggle: PropTypes.func.isRequired
 }
 

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -74,7 +74,7 @@ function generateNewStyle(style, sources, layers) {
   return baseStyle.updateIn(['layers'], arr => arr.push(...layers))
 }
 
-function Map({interactive, style: defaultStyle, baseLocale, commune, voie}) {
+function Map({interactive, style: defaultStyle, commune, voie}) {
   const [map, setMap] = useState(null)
   const [showNumeros, setShowNumeros] = useState(true)
   const [openForm, setOpenForm] = useState(false)
@@ -84,7 +84,7 @@ function Map({interactive, style: defaultStyle, baseLocale, commune, voie}) {
   const [style, setStyle] = useState(defaultStyle)
   const [mapStyle, setMapStyle] = useState(getBaseStyle(defaultStyle))
 
-  const {numeros, reloadNumeros, toponymes, reloadVoies, editingId} = useContext(BalDataContext)
+  const {baseLocale, numeros, reloadNumeros, toponymes, reloadVoies, editingId} = useContext(BalDataContext)
   const {enableMarker, disableMarker} = useContext(MarkerContext)
   const {token} = useContext(TokenContext)
 
@@ -306,7 +306,6 @@ Map.propTypes = {
     'ortho',
     'vector'
   ]),
-  baseLocale: PropTypes.object,
   commune: PropTypes.object,
   voie: PropTypes.object
 }
@@ -314,7 +313,6 @@ Map.propTypes = {
 Map.defaultProps = {
   interactive: true,
   style: 'vector',
-  baseLocale: null,
   commune: null,
   voie: null
 }

--- a/components/settings.js
+++ b/components/settings.js
@@ -8,6 +8,7 @@ import TokenContext from '../contexts/token'
 
 import {useInput} from '../hooks/input'
 import SettingsContext from '../contexts/settings'
+import {validateEmail} from '../lib/utils/email'
 
 const Settings = React.memo(({baseLocale}) => {
   const [isLoading, setIsLoading] = useState(false)
@@ -30,13 +31,18 @@ const Settings = React.memo(({baseLocale}) => {
   const onAddEmail = useCallback(e => {
     e.preventDefault()
 
+    if (validateEmail(email)) {
     setBalEmails(emails => [...emails, email])
     resetEmail()
+    } else {
+      setError('Cet email n’est pas valide')
+    }
   }, [email, resetEmail])
 
   const onSubmit = useCallback(async e => {
     e.preventDefault()
 
+    setError(null)
     setIsLoading(true)
 
     try {
@@ -51,7 +57,13 @@ const Settings = React.memo(({baseLocale}) => {
     }
 
     setIsLoading(false)
-  }, [baseLocale._id, nom, balEmails, token])
+
+  useEffect(() => {
+    if (error) {
+      setError(null)
+    }
+  }, [email]) // eslint-disable-line react-hooks/exhaustive-deps
+
 
   return (
     <SideSheet
@@ -128,6 +140,7 @@ const Settings = React.memo(({baseLocale}) => {
                 width='100%'
                 placeholder='Ajouter une adresse email…'
                 maxWidth={400}
+                isInvalid={Boolean(error)}
                 value={email}
                 onChange={onEmailChange}
               />

--- a/components/settings.js
+++ b/components/settings.js
@@ -55,7 +55,7 @@ const Settings = React.memo(({nomBaseLocale}) => {
 
     try {
       await updateBaseLocale(baseLocale._id, {
-        nom: nomInput,
+        nom: nomInput.trim(),
         emails: balEmails
       }, token)
 
@@ -115,7 +115,7 @@ const Settings = React.memo(({nomBaseLocale}) => {
               required
               name='nom'
               id='nom'
-              value={nomInput || baseLocale.nom}
+              value={nomInput}
               maxWidth={600}
               disabled={isLoading}
               label='Nom'
@@ -159,7 +159,7 @@ const Settings = React.memo(({nomBaseLocale}) => {
                 width='100%'
                 placeholder='Ajouter une adresse email…'
                 maxWidth={400}
-                isInvalid={Boolean(error)}
+                isInvalid={Boolean(error && error.includes('mail'))}
                 value={email}
                 onChange={onEmailChange}
               />

--- a/components/settings.js
+++ b/components/settings.js
@@ -1,12 +1,13 @@
 import React, {useState, useContext, useEffect, useCallback} from 'react'
 import PropTypes from 'prop-types'
-import {Pane, Heading, TextInputField, TextInput, IconButton, Button, Alert, Spinner, Label, toaster} from 'evergreen-ui'
+import {SideSheet, Pane, Heading, TextInputField, TextInput, IconButton, Button, Alert, Spinner, Label, toaster} from 'evergreen-ui'
 
-import {updateBaseLocale} from '../../lib/bal-api'
+import {updateBaseLocale} from '../lib/bal-api'
 
-import TokenContext from '../../contexts/token'
+import TokenContext from '../contexts/token'
 
-import {useInput} from '../../hooks/input'
+import {useInput} from '../hooks/input'
+import SettingsContext from '../contexts/settings'
 
 const Settings = React.memo(({baseLocale}) => {
   const [isLoading, setIsLoading] = useState(false)
@@ -15,6 +16,7 @@ const Settings = React.memo(({baseLocale}) => {
   const [email, onEmailChange, resetEmail] = useInput()
   const [error, setError] = useState()
 
+  const {showSettings, setShowSettings} = useContext(SettingsContext)
   const {token, emails} = useContext(TokenContext)
 
   useEffect(() => {
@@ -43,7 +45,7 @@ const Settings = React.memo(({baseLocale}) => {
         emails: balEmails
       }, token)
 
-      toaster.success('La Base Adresse Locale a été modifiée avec succès !')
+      toaster.success('La Base Adresse Locale a été modifiée avec succès !')
     } catch (error) {
       setError(error.message)
     }
@@ -52,7 +54,10 @@ const Settings = React.memo(({baseLocale}) => {
   }, [baseLocale._id, nom, balEmails, token])
 
   return (
-    <>
+    <SideSheet
+      isShown={showSettings}
+      onCloseComplete={() => setShowSettings(false)}
+    >
       <Pane
         flexShrink={0}
         elevation={0}
@@ -159,7 +164,7 @@ const Settings = React.memo(({baseLocale}) => {
           <Spinner size={64} margin='auto' />
         )}
       </Pane>
-    </>
+    </SideSheet>
   )
 })
 

--- a/contexts/bal-data.js
+++ b/contexts/bal-data.js
@@ -1,7 +1,9 @@
 import React, {useState, useMemo, useCallback, useEffect, useContext} from 'react'
 import PropTypes from 'prop-types'
 
-import {getCommuneGeoJson, getNumeros, getVoies, getVoie} from '../lib/bal-api'
+import {getCommuneGeoJson, getNumeros, getVoies, getVoie, getBaseLocale} from '../lib/bal-api'
+
+import {getPublishedBasesLocales} from '../lib/adresse-backend'
 
 import TokenContext from './token'
 
@@ -13,6 +15,7 @@ export const BalDataContextProvider = React.memo(({balId, codeCommune, idVoie, .
   const [numeros, setNumeros] = useState()
   const [voies, setVoies] = useState()
   const [voie, setVoie] = useState()
+  const [baseLocale, setBaseLocal] = useState({})
 
   const {token} = useContext(TokenContext)
 
@@ -58,6 +61,16 @@ export const BalDataContextProvider = React.memo(({balId, codeCommune, idVoie, .
     }
   }, [idVoie])
 
+  const reloadBaseLocale = useCallback(async () => {
+    if (balId) {
+      const baseLocale = await getBaseLocale(balId)
+      const publishedBasesLocales = await getPublishedBasesLocales()
+      baseLocale.published = Boolean(publishedBasesLocales.find(bal => bal._id === baseLocale._id))
+
+      setBaseLocal(baseLocale)
+    }
+  }, [balId])
+
   const setEditingId = useCallback(editingId => {
     if (token) {
       _setEditingId(editingId)
@@ -85,19 +98,25 @@ export const BalDataContextProvider = React.memo(({balId, codeCommune, idVoie, .
     reloadVoies()
   }, [reloadVoies])
 
+  useEffect(() => {
+    reloadBaseLocale()
+  }, [reloadBaseLocale])
+
   return (
     <BalDataContext.Provider
       value={{
         editingId,
         editingItem,
         geojson,
+        baseLocale,
         voie,
         numeros,
         voies,
         toponymes,
         setEditingId,
         reloadNumeros,
-        reloadVoies
+        reloadVoies,
+        reloadBaseLocale
       }}
       {...props}
     />

--- a/contexts/settings.js
+++ b/contexts/settings.js
@@ -1,0 +1,21 @@
+import React, {useState} from 'react'
+
+const SettingsContext = React.createContext()
+
+export function SettingsContextProvider(props) {
+  const [showSettings, setShowSettings] = useState(false)
+
+  return (
+    <SettingsContext.Provider
+      value={{
+        showSettings,
+        setShowSettings
+      }}
+      {...props}
+    />
+  )
+}
+
+export const SettingsContextConsumer = SettingsContext.Consumer
+
+export default SettingsContext

--- a/contexts/token.js
+++ b/contexts/token.js
@@ -42,8 +42,12 @@ export function TokenContextProvider({balId, token, ...props}) {
     }
   }, [verify, balId, token])
 
+  const reloadEmails = useCallback(async () => {
+    verify(getBalToken(balId))
+  }, [verify, balId])
+
   return (
-    <TokenContext.Provider value={state} {...props} />
+    <TokenContext.Provider value={{...state, reloadEmails}} {...props} />
   )
 }
 

--- a/lib/utils/email.js
+++ b/lib/utils/email.js
@@ -1,0 +1,4 @@
+export function validateEmail(email) {
+  const re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
+  return re.test(String(email).toLowerCase())
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -22,8 +22,6 @@ import {TokenContextProvider} from '../contexts/token'
 import {BalDataContextProvider} from '../contexts/bal-data'
 
 import useWindowSize from '../hooks/window-size'
-import useError from '../hooks/error'
-import {getPublishedBasesLocales} from '../lib/adresse-backend'
 import Settings from '../components/settings'
 
 const layoutMap = {
@@ -32,8 +30,6 @@ const layoutMap = {
 }
 
 function App({error, Component, pageProps, query}) {
-  const [baseLocale, setBaseLocale] = useState(null)
-  const [setError] = useError(null)
   const {innerWidth} = useWindowSize()
   const [isShown, setIsShown] = useState(false)
   const [isHidden, setIsHidden] = useState(false)
@@ -57,38 +53,14 @@ function App({error, Component, pageProps, query}) {
   }, [layout, isHidden])
 
   const topOffset = useMemo(() => {
-    return baseLocale ? 40 : 0
-  }, [baseLocale])
+    return pageProps.baseLocale ? 40 : 0
+  }, [pageProps.baseLocale])
 
   useEffect(() => {
     if (innerWidth && innerWidth < 700) {
       setIsShown(true)
     }
   }, [innerWidth])
-
-  useEffect(() => {
-    const expandWithPublished = async baseLocale => {
-      const publishedBasesLocales = await getPublishedBasesLocales()
-      baseLocale.published = Boolean(publishedBasesLocales.find(bal => bal._id === baseLocale._id))
-      setBaseLocale(baseLocale)
-    }
-
-    if (pageProps.baseLocale) {
-      const {baseLocale} = pageProps
-      expandWithPublished(baseLocale)
-    } else {
-      setBaseLocale(null)
-    }
-  }, [pageProps, pageProps.baseLocale])
-
-  const refreshBaseLocale = async () => {
-    try {
-      const baseLocale = await getBaseLocale(query.balId)
-      setBaseLocale(baseLocale)
-    } catch (error) {
-      setError(error.message)
-    }
-  }
 
   return (
     <Container>
@@ -120,15 +92,13 @@ function App({error, Component, pageProps, query}) {
 
               <Help />
 
-              {baseLocale && (
+              {pageProps.baseLocale && (
                 <SettingsContextProvider>
-                  <Settings baseLocale={baseLocale} />
+                  <Settings nomBaseLocale={pageProps.baseLocale.nom} />
                   <Header
                     {...pageProps}
-                    baseLocale={baseLocale}
                     layout={layout}
                     isSidebarHidden={isHidden}
-                    refreshBaseLocale={refreshBaseLocale}
                     onToggle={onToggle}
                   />
                 </SettingsContextProvider>
@@ -139,7 +109,6 @@ function App({error, Component, pageProps, query}) {
                 left={leftOffset}
                 animate={layout === 'sidebar'}
                 interactive={layout === 'sidebar'}
-                baseLocale={baseLocale}
                 commune={pageProps.commune}
                 voie={pageProps.voie}
               />

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -16,6 +16,7 @@ import Map from '../components/map'
 import Help from '../components/help'
 
 import {HelpContextProvider} from '../contexts/help'
+import {SettingsContextProvider} from '../contexts/settings'
 import {MarkerContextProvider} from '../contexts/marker'
 import {TokenContextProvider} from '../contexts/token'
 import {BalDataContextProvider} from '../contexts/bal-data'
@@ -23,6 +24,7 @@ import {BalDataContextProvider} from '../contexts/bal-data'
 import useWindowSize from '../hooks/window-size'
 import useError from '../hooks/error'
 import {getPublishedBasesLocales} from '../lib/adresse-backend'
+import Settings from '../components/settings'
 
 const layoutMap = {
   fullscreen: Fullscreen,
@@ -119,14 +121,17 @@ function App({error, Component, pageProps, query}) {
               <Help />
 
               {baseLocale && (
-                <Header
-                  {...pageProps}
-                  baseLocale={baseLocale}
-                  layout={layout}
-                  isSidebarHidden={isHidden}
-                  refreshBaseLocale={refreshBaseLocale}
-                  onToggle={onToggle}
-                />
+                <SettingsContextProvider>
+                  <Settings baseLocale={baseLocale} />
+                  <Header
+                    {...pageProps}
+                    baseLocale={baseLocale}
+                    layout={layout}
+                    isSidebarHidden={isHidden}
+                    refreshBaseLocale={refreshBaseLocale}
+                    onToggle={onToggle}
+                  />
+                </SettingsContextProvider>
               )}
 
               <Map

--- a/pages/bal/index.js
+++ b/pages/bal/index.js
@@ -7,6 +7,7 @@ import {addCommune, removeCommune, populateCommune} from '../../lib/bal-api'
 import {getCommune} from '../../lib/geo-api'
 
 import TokenContext from '../../contexts/token'
+import BalDataContext from '../../contexts/bal-data'
 
 import useHelp from '../../hooks/help'
 import useFuse from '../../hooks/fuse'
@@ -21,6 +22,7 @@ const Index = React.memo(({baseLocale, defaultCommunes}) => {
   const [toRemove, setToRemove] = useState(null)
 
   const {token} = useContext(TokenContext)
+  const {baseLocale: {nom}} = useContext(BalDataContext)
 
   useHelp(1)
   const [filtered, onFilter] = useFuse(communes, 200, {
@@ -81,7 +83,7 @@ const Index = React.memo(({baseLocale, defaultCommunes}) => {
         background='tint1'
         padding={16}
       >
-        <Heading>{baseLocale.nom}</Heading>
+        <Heading>{nom || baseLocale.nom}</Heading>
         <Text>{communes.length} commune{communes.length > 1 ? 's' : ''}</Text>
       </Pane>
       <Pane

--- a/server/routes.js
+++ b/server/routes.js
@@ -20,13 +20,6 @@ module.exports = app => {
     })
   })
 
-  router.get('/bal/:balId/settings', (req, res) => {
-    app.render(req, res, '/bal/settings', {
-      ...req.query,
-      balId: req.params.balId
-    })
-  })
-
   router.get('/bal/:balId/:token', (req, res) => {
     app.render(req, res, '/bal', {
       ...req.query,


### PR DESCRIPTION
Cette PR a pour effet de supprimer la page `/settings` et de la remplacer par un menu latéral. Cette évolutions prépare l'arrivée de futurs nouveaux paramètres pour lesquels le changements de page aurait détérioré l'expérience utilisateur.

#### Évolutions
- Rafraichissement dynamique des meta données de la base adresse locale
- Sauvegarde possible uniquement si des changements sont détectés
- Amélioration de la validation des champs