### PR TITLE
Correction de la mise à jour de la voie lorsque qu'un numéro n'est pas ajouté dans la voie par défaut 

### DIFF
--- a/pages/bal/index.js
+++ b/pages/bal/index.js
@@ -181,7 +181,8 @@ Index.getInitialProps = async ({baseLocale}) => {
 
 Index.propTypes = {
   baseLocale: PropTypes.shape({
-    _id: PropTypes.string.isRequired
+    _id: PropTypes.string.isRequired,
+    nom: PropTypes.string.isRequired
   }).isRequired,
   defaultCommunes: PropTypes.array
 }


### PR DESCRIPTION
Si un numéro est ajouté dans la voie `B` alors que la voie `A` est sélectionnée alors les numéro affichés sur la carte et le menu latéral se mettent à jour correctement mais pas la voie sélectionné reste la voie `A`.

Ce correctif redirige l'utilisateur vers la bonne voie. 