### PR TITLE
Création de Base Adresse Locale de test

### DIFF
--- a/components/header/index.js
+++ b/components/header/index.js
@@ -93,12 +93,13 @@ const Header = React.memo(({commune, voie, layout, isSidebarHidden, onToggle}) =
       />
 
       <Pane marginLeft='auto' display='flex'>
-        <Publication
-          token={token}
-          status={baseLocale.published ? 'published' : baseLocale.status}
-          onChangeStatus={handleChangeStatus}
-          onPublish={handlePublication}
-        />
+        {!baseLocale.isTest && (
+          <Publication
+            token={token}
+            status={baseLocale.published ? 'published' : baseLocale.status}
+            onChangeStatus={handleChangeStatus}
+            onPublish={handlePublication}
+          />)}
 
         <IconButton
           height={24}

--- a/components/settings.js
+++ b/components/settings.js
@@ -117,7 +117,7 @@ const Settings = React.memo(({nomBaseLocale}) => {
               id='nom'
               value={nomInput}
               maxWidth={600}
-              disabled={isLoading}
+              disabled={isLoading || baseLocale.isTest}
               label='Nom'
               placeholder='Nom'
               onChange={onNomInputChange}
@@ -161,6 +161,7 @@ const Settings = React.memo(({nomBaseLocale}) => {
                 maxWidth={400}
                 isInvalid={Boolean(error && error.includes('mail'))}
                 value={email}
+                disabled={baseLocale.isTest}
                 onChange={onEmailChange}
               />
               {email && !balEmails.includes(email) && (
@@ -195,6 +196,16 @@ const Settings = React.memo(({nomBaseLocale}) => {
         ) : (
           <Spinner size={64} margin='auto' />
         )}
+      </Pane>
+
+      <Pane padding={16}>
+        <Alert
+          intent='none'
+          title='Version d’essai de l’éditeur de base adresse locale'
+          marginBottom={32}
+        >
+          Il est impossible de modifier les paramètres de la base adresse locale en version d’essai.
+        </Alert>
       </Pane>
     </SideSheet>
   )

--- a/components/user-bases-locales.js
+++ b/components/user-bases-locales.js
@@ -41,7 +41,7 @@ function UserBasesLocales() {
   }
 
   return (
-    <Pane flex={2}>
+    <Pane flex={2} minHeight={200}>
       <Heading padding={16} size={400}>Mes Bases Adresse Locales</Heading>
       <BasesLocalesList basesLocales={basesLocales} updateBasesLocales={setBalAccess} />
     </Pane>

--- a/pages/index.js
+++ b/pages/index.js
@@ -13,9 +13,6 @@ const UserBasesLocales = dynamic(() => import('../components/user-bases-locales'
 })
 
 function Index() {
-  const onCreate = () => {
-    Router.push('/new')
-  }
 
   return (
     <>
@@ -36,6 +33,7 @@ function Index() {
           height={100}
           alignItems='center'
           justifyContent='center'
+          flexDirection='column'
           padding={16}
         >
           <Button
@@ -43,9 +41,17 @@ function Index() {
             marginTop={10}
             appearance='primary'
             height={40}
-            onClick={onCreate}
+            onClick={() => Router.push('/new')}
           >
             Créer Base Adresse Locale
+          </Button>
+          <Button
+            marginTop={10}
+            appearance='alt'
+            height={40}
+            onClick={() => Router.push('/new?test=1')}
+          >
+            Essayer l’éditeur de base adresse locale
           </Button>
         </Pane>
 

--- a/pages/new/index.js
+++ b/pages/new/index.js
@@ -10,8 +10,9 @@ import HelpContext from '../../contexts/help'
 
 import CreateForm from './create-form'
 import UploadForm from './upload-form'
+import TestForm from './test-form'
 
-function Index({defaultCommune}) {
+function Index({defaultCommune, isTest}) {
   const [index, setIndex] = useState(0)
   const {showHelp, setShowHelp, setSelectedIndex} = useContext(HelpContext)
 
@@ -31,25 +32,30 @@ function Index({defaultCommune}) {
         </Paragraph>
       </Pane>
 
-      <TabNavigation display='flex' marginLeft={16}>
-        {['Créer', 'Importer un fichier CSV'].map((tab, idx) => (
-          <Tab key={tab} id={tab} isSelected={index === idx} onSelect={() => setIndex(idx)}>
-            {tab}
-          </Tab>
-        ))}
-      </TabNavigation>
+      {isTest ? (
+        <TestForm />
+      ) :
+        (<>
+          <TabNavigation display='flex' marginLeft={16}>
+            {['Créer', 'Importer un fichier CSV'].map((tab, idx) => (
+              <Tab key={tab} id={tab} isSelected={index === idx} onSelect={() => setIndex(idx)}>
+                {tab}
+              </Tab>
+            ))}
+          </TabNavigation>
 
-      <Pane flex={1} overflowY='scroll'>
-        {index === 0 ? (
-          <CreateForm defaultCommune={defaultCommune} />
-        ) : (
-          <UploadForm />
-        )}
+          <Pane flex={1} overflowY='scroll'>
+            {index === 0 ? (
+              <CreateForm defaultCommune={defaultCommune} isTest={isTest} />
+            ) : (
+              <UploadForm />
+            )}
+          </Pane>
+        </>)}
 
-        <Pane display='flex' justifyContent='space-between' alignItems='center' flex={1} margin={16} marginTop={32}>
-          <BackButton is='a' href='/'>Retour</BackButton>
-          <Button height={32} iconAfter='help' onClick={handleHelp}>Besoin d’aide</Button>
-        </Pane>
+      <Pane display='flex' justifyContent='space-between' alignItems='center' flex={1} margin={16} marginTop={32}>
+        <BackButton is='a' href='/'>Retour</BackButton>
+        <Button height={32} iconAfter='help' onClick={handleHelp}>Besoin d’aide</Button>
       </Pane>
     </Pane>
   )
@@ -65,16 +71,19 @@ Index.getInitialProps = async ({query}) => {
 
   return {
     defaultCommune,
+    isTest: query.test === '1',
     layout: 'fullscreen'
   }
 }
 
 Index.propTypes = {
-  defaultCommune: PropTypes.string
+  defaultCommune: PropTypes.string,
+  isTest: PropTypes.bool
 }
 
 Index.defaultProps = {
-  defaultCommune: null
+  defaultCommune: null,
+  isTest: false
 }
 
 export default Index

--- a/pages/new/test-form.js
+++ b/pages/new/test-form.js
@@ -1,0 +1,81 @@
+import React, {useState, useCallback} from 'react'
+import PropTypes from 'prop-types'
+import Router from 'next/router'
+import {Pane, Checkbox, Button} from 'evergreen-ui'
+
+import {storeBalAccess} from '../../lib/tokens'
+import {createBaseLocale, addCommune, populateCommune} from '../../lib/bal-api'
+
+import useFocus from '../../hooks/focus'
+import {useCheckboxInput} from '../../hooks/input'
+
+import {CommuneSearchField} from '../../components/commune-search'
+
+function TestForm({defaultCommune}) {
+  const [isLoading, setIsLoading] = useState(false)
+
+  const [populate, onPopulateChange] = useCheckboxInput(true)
+  const [commune, setCommune] = useState(defaultCommune ? defaultCommune.code : null)
+  const focusRef = useFocus()
+
+  const onSelect = useCallback(commune => {
+    setCommune(commune.code)
+  }, [])
+  const onSubmit = useCallback(async e => {
+    e.preventDefault()
+
+    setIsLoading(true)
+
+    const bal = await createBaseLocale({isTest: true})
+
+    storeBalAccess(bal._id, bal.token)
+
+    await addCommune(bal._id, commune, bal.token)
+
+    if (populate) {
+      await populateCommune(bal._id, commune, bal.token)
+    }
+
+    Router.push(
+      `/bal/commune?balId=${bal._id}&codeCommune=${commune}`,
+      `/bal/${bal._id}/communes/${commune}`
+    )
+  }, [commune, populate])
+
+  return (
+    <Pane is='form' margin={16} padding={16} overflowY='scroll' background='tint2' onSubmit={onSubmit}>
+      <CommuneSearchField
+        required
+        innerRef={focusRef}
+        id='commune'
+        defaultSelectedItem={defaultCommune}
+        label='Commune'
+        maxWidth={500}
+        disabled={isLoading}
+        hint='Vous pourrez ajouter plusieurs communes à la Base Adresse Locale plus tard.'
+        onSelect={onSelect}
+      />
+
+      <Checkbox
+        label='Importer les voies et numéros depuis la BAN'
+        checked={populate}
+        disabled={isLoading}
+        onChange={onPopulateChange}
+      />
+
+      <Button height={40} marginTop={8} type='submit' appearance='primary' isLoading={isLoading}>
+        {isLoading ? 'En cours de création…' : 'Créer la Base Adresse Locale'}
+      </Button>
+    </Pane>
+  )
+}
+
+TestForm.propTypes = {
+  defaultCommune: PropTypes.object
+}
+
+TestForm.defaultProps = {
+  defaultCommune: null
+}
+
+export default TestForm


### PR DESCRIPTION
Permet aux utilisateurs d'essayer l'éditeur sans fournir d'adresse email ou nommer leur BAL.

### Nouveau bouton en page d'accueil
![Capture d’écran 2020-08-05 à 18 06 53](https://user-images.githubusercontent.com/7040549/89436919-316b8000-d747-11ea-8991-d0963f0e32dd.png)

### Formulaire de création
![Capture d’écran 2020-08-05 à 18 07 05](https://user-images.githubusercontent.com/7040549/89436922-329cad00-d747-11ea-93ca-c826d2dfb775.png)

### Désactivation de certaines fonctionnalités
La publication ainsi que la modification des paramètres de la Base Adresse Locale sont désactivés pour les BAL de test.
![Capture d’écran 2020-08-05 à 18 07 46](https://user-images.githubusercontent.com/7040549/89436927-33354380-d747-11ea-92e0-9e65bdde2b01.png)

⚠️ Cette PR nécessite https://github.com/etalab/api-bal/pull/200

Fix #133 