### PR TITLE
Correction du changement de nom de la voie lors d'un changement de voie depuis la carte

### DIFF
--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -17,7 +17,7 @@ import VoieEditor from '../../components/bal/voie-editor'
 import NumeroEditor from '../../components/bal/numero-editor'
 
 const Voie = React.memo(({voie, defaultNumeros}) => {
-  const [editedVoie, setEditedVoie] = useState(voie)
+  const [editedVoie, setEditedVoie] = useState(null)
   const [isEdited, setEdited] = useState(false)
   const [hovered, setHovered] = useState(false)
   const [isAdding, setIsAdding] = useState(false)
@@ -115,6 +115,12 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
       setEditingId(null)
     }
   }, [isEdited, setEditingId])
+
+  useEffect(() => {
+    if (voie) {
+      setEditedVoie(null)
+    }
+  }, [voie])
 
   return (
     <>


### PR DESCRIPTION
Une variable temporaire n'était pas réinitialisée lors du changement de voie ce qui avait pour effet de persister le nom de la voie précédente.