### PR TITLE
Ajout de la numérotation métrique

### DIFF
--- a/DEVELOPER_NOTES.md
+++ b/DEVELOPER_NOTES.md
@@ -1,0 +1,2 @@
+### React Map GL Draw
+`react-map-gl-draw` needs to install `@turf/difference` and force the version 6.0.1. More information here -> https://www.npmjs.com/package/react-map-gl-draw#know-issues

--- a/components/bal/draw-editor.js
+++ b/components/bal/draw-editor.js
@@ -1,0 +1,71 @@
+import React, {useContext, useCallback, useMemo} from 'react'
+import PropTypes from 'prop-types'
+import {Pane, Button, Alert} from 'evergreen-ui'
+import {isEqual} from 'lodash'
+
+import DrawContext from '../../contexts/draw'
+
+const DrawEditor = ({lineVoie}) => {
+  const {modeId, data, setData} = useContext(DrawContext)
+
+  const handleCancel = useCallback(() => {
+    setData(lineVoie)
+  }, [setData, lineVoie])
+
+  const isModified = useMemo(() => {
+    if (data && lineVoie) {
+      return !isEqual(data.geometry.coordinates, lineVoie.geometry.coordinates, isEqual)
+    }
+
+    return false
+  }, [data, lineVoie])
+
+  return (
+    <Pane>
+      {isModified && (
+        <Button
+          type='button'
+          marginY={8} marginRight={12}
+          iconBefore='edit'
+          onClick={handleCancel}
+        >
+        Annuler les modifications
+        </Button>
+      )}
+
+      {data && (
+        <Button
+          type='button'
+          intent='danger'
+          marginY={8} marginRight={12}
+          iconBefore='eraser'
+          onClick={() => setData(null)}
+        >
+        Effacer le tracé
+        </Button>
+      )}
+
+      <Alert
+        intent='none'
+        title='Utilisez la carte pour dessiner le tracer de la voie'
+        marginBottom={32}
+      >
+        {modeId === 'drawLineString' ?
+          'Cliquez sur la carte pour indiquer le début de la voie, puis ajouter de nouveaux points afin de tracer votre voie. Une fois terminé, cliquez sur le dernier point afin d’indiquer la fin de la voie.' :
+          'Modifier le tracé de la voie directement depuis la carte.'
+        }
+      </Alert>
+
+    </Pane>
+  )
+}
+
+DrawEditor.defaultProps = {
+  lineVoie: null
+}
+
+DrawEditor.propTypes = {
+  lineVoie: PropTypes.object
+}
+
+export default DrawEditor

--- a/components/bal/draw-editor.js
+++ b/components/bal/draw-editor.js
@@ -5,20 +5,20 @@ import {isEqual} from 'lodash'
 
 import DrawContext from '../../contexts/draw'
 
-const DrawEditor = ({lineVoie}) => {
+const DrawEditor = ({trace}) => {
   const {modeId, data, setData} = useContext(DrawContext)
 
   const handleCancel = useCallback(() => {
-    setData(lineVoie)
-  }, [setData, lineVoie])
+    setData(trace)
+  }, [setData, trace])
 
   const isModified = useMemo(() => {
-    if (data && lineVoie) {
-      return !isEqual(data.geometry.coordinates, lineVoie.geometry.coordinates, isEqual)
+    if (data && trace) {
+      return !isEqual(data.geometry.coordinates, trace.geometry.coordinates, isEqual)
     }
 
     return false
-  }, [data, lineVoie])
+  }, [data, trace])
 
   return (
     <Pane>
@@ -61,11 +61,11 @@ const DrawEditor = ({lineVoie}) => {
 }
 
 DrawEditor.defaultProps = {
-  lineVoie: null
+  trace: null
 }
 
 DrawEditor.propTypes = {
-  lineVoie: PropTypes.object
+  trace: PropTypes.object
 }
 
 export default DrawEditor

--- a/components/bal/draw-editor.js
+++ b/components/bal/draw-editor.js
@@ -1,7 +1,7 @@
 import React, {useContext, useCallback, useMemo} from 'react'
 import PropTypes from 'prop-types'
-import {Pane, Button, Alert} from 'evergreen-ui'
 import {isEqual} from 'lodash'
+import {Pane, Heading, Button, Alert} from 'evergreen-ui'
 
 import DrawContext from '../../contexts/draw'
 
@@ -21,7 +21,21 @@ const DrawEditor = ({trace}) => {
   }, [data, trace])
 
   return (
-    <Pane>
+    <Pane borderLeft='default' paddingX={12} marginBottom={12}>
+      <Heading is='h4'>
+        Tracer de la voie
+      </Heading>
+
+      <Alert
+        intent='none'
+        title='Utilisez la carte pour dessiner le tracer de la voie'
+      >
+        {modeId === 'drawLineString' ?
+          'Cliquez sur la carte pour indiquer le début de la voie, puis ajouter de nouveaux points afin de tracer votre voie. Une fois terminé, cliquez sur le dernier point afin d’indiquer la fin de la voie.' :
+          'Modifier le tracé de la voie directement depuis la carte.'
+        }
+      </Alert>
+
       {isModified && (
         <Button
           type='button'
@@ -36,6 +50,7 @@ const DrawEditor = ({trace}) => {
       {data && (
         <Button
           type='button'
+          appearance='primary'
           intent='danger'
           marginY={8} marginRight={12}
           iconBefore='eraser'
@@ -44,17 +59,6 @@ const DrawEditor = ({trace}) => {
         Effacer le tracé
         </Button>
       )}
-
-      <Alert
-        intent='none'
-        title='Utilisez la carte pour dessiner le tracer de la voie'
-        marginBottom={32}
-      >
-        {modeId === 'drawLineString' ?
-          'Cliquez sur la carte pour indiquer le début de la voie, puis ajouter de nouveaux points afin de tracer votre voie. Une fois terminé, cliquez sur le dernier point afin d’indiquer la fin de la voie.' :
-          'Modifier le tracé de la voie directement depuis la carte.'
-        }
-      </Alert>
 
     </Pane>
   )

--- a/components/bal/draw-editor.js
+++ b/components/bal/draw-editor.js
@@ -9,12 +9,16 @@ const DrawEditor = ({trace}) => {
   const {modeId, data, setData} = useContext(DrawContext)
 
   const handleCancel = useCallback(() => {
-    setData(trace)
+    setData({
+      type: 'Feature',
+      properties: {},
+      geometry: trace
+    })
   }, [setData, trace])
 
   const isModified = useMemo(() => {
     if (data && trace) {
-      return !isEqual(data.geometry.coordinates, trace.geometry.coordinates, isEqual)
+      return !isEqual(data.geometry.coordinates, trace.coordinates, isEqual)
     }
 
     return false

--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -122,11 +122,11 @@ function NumeroEditor({initialVoie, initialValue, onSubmit, onCancel}) {
         properties: {},
         geometry: {
           type: 'Point',
-          coordinates: trace.geometry.coordinates[0]
+          coordinates: trace.coordinates[0]
         }
       }
 
-      const to = nearestPointOnLine(trace, point, {units: 'kilometers'})
+      const to = nearestPointOnLine({type: 'Feature', geometry: trace}, point, {units: 'kilometers'})
       const distance = rhumbDistance(from, to, {units: 'kilometers'}) * 1000
       return distance.toFixed(0)
     }

--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -107,8 +107,8 @@ function NumeroEditor({initialVoie, initialValue, onSubmit, onCancel}) {
   }, [initialValue])
 
   const numeroSuggestion = useMemo(() => {
-    if (marker && voie.lineVoie) {
-      const {lineVoie} = voie
+    if (marker && voie.trace) {
+      const {trace} = voie
       const point = {
         type: 'Feature',
         properties: {},
@@ -122,11 +122,11 @@ function NumeroEditor({initialVoie, initialValue, onSubmit, onCancel}) {
         properties: {},
         geometry: {
           type: 'Point',
-          coordinates: lineVoie.geometry.coordinates[0]
+          coordinates: trace.geometry.coordinates[0]
         }
       }
 
-      const to = nearestPointOnLine(lineVoie, point, {units: 'kilometers'})
+      const to = nearestPointOnLine(trace, point, {units: 'kilometers'})
       const distance = rhumbDistance(from, to, {units: 'kilometers'}) * 1000
       return distance.toFixed(0)
     }
@@ -244,7 +244,7 @@ function NumeroEditor({initialVoie, initialValue, onSubmit, onCancel}) {
 NumeroEditor.propTypes = {
   initialVoie: PropTypes.shape({
     _id: PropTypes.string.isRequired,
-    lineVoie: PropTypes.object
+    trace: PropTypes.object
   }).isRequired,
   initialValue: PropTypes.shape({
     numero: PropTypes.number.isRequired,

--- a/components/bal/voie-editor.js
+++ b/components/bal/voie-editor.js
@@ -46,7 +46,7 @@ function VoieEditor({initialValue, onSubmit, onCancel, isEnabledComplement}) {
 
     const body = {
       nom,
-      typeNumerotation: isMetric ? 'metric' : 'numeric',
+      typeNumerotation: isMetric ? 'metrique' : 'numerique',
       complement: complement.length > 1 ? complement : null,
       trace: data
     }

--- a/components/bal/voie-editor.js
+++ b/components/bal/voie-editor.js
@@ -2,6 +2,9 @@ import React, {useState, useMemo, useContext, useCallback, useEffect} from 'reac
 import PropTypes from 'prop-types'
 import {Pane, Button, Checkbox, Alert, TextInputField} from 'evergreen-ui'
 
+import {checkIsToponyme} from '../../lib/voie'
+
+import DrawContext from '../../contexts/draw'
 import MarkerContext from '../../contexts/marker'
 
 import {useInput, useCheckboxInput} from '../../hooks/input'
@@ -9,24 +12,33 @@ import useFocus from '../../hooks/focus'
 import useKeyEvent from '../../hooks/key-event'
 
 import PositionEditor from './position-editor'
+import DrawEditor from './draw-editor'
 
 function VoieEditor({initialValue, onSubmit, onCancel, isEnabledComplement}) {
   const position = initialValue ? initialValue.positions[0] : null
 
   const [isLoading, setIsLoading] = useState(false)
-  const [isToponyme, onIsToponymeChange] = useCheckboxInput(Boolean(position))
+  const [isToponyme, onIsToponymeChange] = useCheckboxInput(checkIsToponyme(initialValue))
+  const [isMetric, onIsMetricChange] = useCheckboxInput(initialValue ? initialValue.typeNumerotation === 'metric' : false)
   const [nom, onNomChange] = useInput(initialValue ? initialValue.nom : '')
   const [complement, onComplementChange] = useInput(initialValue ? initialValue.complement : '')
   const [positionType, onPositionTypeChange] = useInput(position ? position.type : 'entrée')
   const [error, setError] = useState()
   const setRef = useFocus()
 
+  const {data, setModeId, setData} = useContext(DrawContext)
   const {
     enabled,
     marker,
     enableMarker,
     disableMarker
   } = useContext(MarkerContext)
+
+  const onUnmount = useCallback(() => {
+    disableMarker()
+    setData(null)
+    setModeId(null)
+  }, [disableMarker, setData, setModeId])
 
   const onFormSubmit = useCallback(async e => {
     e.preventDefault()
@@ -35,7 +47,9 @@ function VoieEditor({initialValue, onSubmit, onCancel, isEnabledComplement}) {
 
     const body = {
       nom,
-      complement: complement.length > 1 ? complement : null
+      typeNumerotation: isMetric ? 'metric' : 'numeric',
+      complement: complement.length > 1 ? complement : null,
+      lineVoie: data
     }
 
     if (marker) {
@@ -52,19 +66,19 @@ function VoieEditor({initialValue, onSubmit, onCancel, isEnabledComplement}) {
 
     try {
       await onSubmit(body)
-      disableMarker()
+      onUnmount()
     } catch (error) {
       setIsLoading(false)
       setError(error.message)
     }
-  }, [nom, marker, positionType, onSubmit, disableMarker, complement])
+  }, [nom, isMetric, complement, data, marker, positionType, onSubmit, onUnmount])
 
   const onFormCancel = useCallback(e => {
     e.preventDefault()
 
-    disableMarker()
+    onUnmount()
     onCancel()
-  }, [disableMarker, onCancel])
+  }, [onCancel, onUnmount])
 
   const submitLabel = useMemo(() => {
     if (isLoading) {
@@ -88,6 +102,24 @@ function VoieEditor({initialValue, onSubmit, onCancel, isEnabledComplement}) {
       disableMarker()
     }
   }, [enabled, initialValue, disableMarker, enableMarker, isToponyme, position])
+
+  useEffect(() => {
+    if (isMetric) {
+      onIsToponymeChange({target: {checked: false}})
+    }
+  }, [isMetric, onIsToponymeChange])
+
+  useEffect(() => {
+    if (isToponyme) {
+      onIsMetricChange({target: {checked: false}})
+    }
+  }, [isToponyme, onIsMetricChange])
+
+  useEffect(() => {
+    return () => {
+      console.log('UNMOUNT')
+    }
+  }, [])
 
   return (
     <Pane is='form' onSubmit={onFormSubmit}>
@@ -120,12 +152,22 @@ function VoieEditor({initialValue, onSubmit, onCancel, isEnabledComplement}) {
         />
       )}
 
+      <Checkbox
+        checked={isMetric}
+        label='Cette voie utilise la numérotation métrique'
+        onChange={onIsMetricChange}
+      />
+
       {!initialValue && (
         <Checkbox
           checked={isToponyme}
           label='Cette voie est un toponyme'
           onChange={onIsToponymeChange}
         />
+      )}
+
+      {isMetric && (
+        <DrawEditor voieLine={initialValue ? initialValue.lineVoie : null} />
       )}
 
       {isToponyme && marker && (
@@ -171,6 +213,8 @@ VoieEditor.propTypes = {
   initialValue: PropTypes.shape({
     nom: PropTypes.string,
     complement: PropTypes.string,
+    typeNumerotation: PropTypes.string,
+    lineVoie: PropTypes.object,
     positions: PropTypes.array.isRequired
   }),
   onSubmit: PropTypes.func.isRequired,

--- a/components/bal/voie-editor.js
+++ b/components/bal/voie-editor.js
@@ -26,7 +26,7 @@ function VoieEditor({initialValue, onSubmit, onCancel, isEnabledComplement}) {
   const [error, setError] = useState()
   const setRef = useFocus()
 
-  const {data, setModeId, setData} = useContext(DrawContext)
+  const {data, enableDraw, disableDraw, setModeId, setData} = useContext(DrawContext)
   const {
     enabled,
     marker,
@@ -36,9 +36,8 @@ function VoieEditor({initialValue, onSubmit, onCancel, isEnabledComplement}) {
 
   const onUnmount = useCallback(() => {
     disableMarker()
-    setData(null)
-    setModeId(null)
-  }, [disableMarker, setData, setModeId])
+    disableDraw()
+  }, [disableDraw, disableMarker])
 
   const onFormSubmit = useCallback(async e => {
     e.preventDefault()
@@ -71,7 +70,7 @@ function VoieEditor({initialValue, onSubmit, onCancel, isEnabledComplement}) {
       setIsLoading(false)
       setError(error.message)
     }
-  }, [nom, isMetric, complement, data, marker, positionType, onSubmit, onUnmount])
+  }, [nom, isMetric, complement, data, initialValue.lineVoie, marker, positionType, onSubmit, onUnmount])
 
   const onFormCancel = useCallback(e => {
     e.preventDefault()
@@ -106,8 +105,13 @@ function VoieEditor({initialValue, onSubmit, onCancel, isEnabledComplement}) {
   useEffect(() => {
     if (isMetric) {
       onIsToponymeChange({target: {checked: false}})
+
+      setModeId(data ? 'editing' : 'drawLineString')
+      enableDraw()
+    } else {
+      disableDraw()
     }
-  }, [isMetric, onIsToponymeChange])
+  }, [data, disableDraw, enableDraw, isMetric, onIsToponymeChange, setData, setModeId])
 
   useEffect(() => {
     if (isToponyme) {
@@ -117,9 +121,9 @@ function VoieEditor({initialValue, onSubmit, onCancel, isEnabledComplement}) {
 
   useEffect(() => {
     return () => {
-      console.log('UNMOUNT')
+      disableDraw()
     }
-  }, [])
+  }, [disableDraw])
 
   return (
     <Pane is='form' onSubmit={onFormSubmit}>

--- a/components/bal/voie-editor.js
+++ b/components/bal/voie-editor.js
@@ -48,7 +48,7 @@ function VoieEditor({initialValue, onSubmit, onCancel, isEnabledComplement}) {
       nom,
       typeNumerotation: isMetric ? 'metric' : 'numeric',
       complement: complement.length > 1 ? complement : null,
-      lineVoie: data
+      trace: data
     }
 
     if (marker) {
@@ -171,7 +171,7 @@ function VoieEditor({initialValue, onSubmit, onCancel, isEnabledComplement}) {
       )}
 
       {isMetric && (
-        <DrawEditor voieLine={initialValue ? initialValue.lineVoie : null} />
+        <DrawEditor trace={initialValue ? initialValue.trace : null} />
       )}
 
       {isToponyme && marker && (
@@ -218,7 +218,7 @@ VoieEditor.propTypes = {
     nom: PropTypes.string,
     complement: PropTypes.string,
     typeNumerotation: PropTypes.string,
-    lineVoie: PropTypes.object,
+    trace: PropTypes.object,
     positions: PropTypes.array.isRequired
   }),
   onSubmit: PropTypes.func.isRequired,

--- a/components/bal/voie-editor.js
+++ b/components/bal/voie-editor.js
@@ -19,7 +19,7 @@ function VoieEditor({initialValue, onSubmit, onCancel, isEnabledComplement}) {
 
   const [isLoading, setIsLoading] = useState(false)
   const [isToponyme, onIsToponymeChange] = useCheckboxInput(checkIsToponyme(initialValue))
-  const [isMetric, onIsMetricChange] = useCheckboxInput(initialValue ? initialValue.typeNumerotation === 'metric' : false)
+  const [isMetric, onIsMetricChange] = useCheckboxInput(initialValue ? initialValue.typeNumerotation === 'metrique' : false)
   const [nom, onNomChange] = useInput(initialValue ? initialValue.nom : '')
   const [complement, onComplementChange] = useInput(initialValue ? initialValue.complement : '')
   const [positionType, onPositionTypeChange] = useInput(position ? position.type : 'entrée')
@@ -48,7 +48,7 @@ function VoieEditor({initialValue, onSubmit, onCancel, isEnabledComplement}) {
       nom,
       typeNumerotation: isMetric ? 'metrique' : 'numerique',
       complement: complement.length > 1 ? complement : null,
-      trace: data
+      trace: data ? data.geometry : null
     }
 
     if (marker) {

--- a/components/bal/voie-editor.js
+++ b/components/bal/voie-editor.js
@@ -70,7 +70,7 @@ function VoieEditor({initialValue, onSubmit, onCancel, isEnabledComplement}) {
       setIsLoading(false)
       setError(error.message)
     }
-  }, [nom, isMetric, complement, data, initialValue.lineVoie, marker, positionType, onSubmit, onUnmount])
+  }, [nom, isMetric, complement, data, marker, positionType, onSubmit, onUnmount])
 
   const onFormCancel = useCallback(e => {
     e.preventDefault()

--- a/components/map/control.js
+++ b/components/map/control.js
@@ -2,7 +2,7 @@ import React, {useCallback} from 'react'
 import PropTypes from 'prop-types'
 import {Pane, Tooltip, Icon, Position} from 'evergreen-ui'
 
-function NumeroSwitch({enabled, icon, enabledHint, disabledHint, onChange}) {
+function Control({enabled, icon, enabledHint, disabledHint, onChange}) {
   const onToggle = useCallback(e => {
     e.stopPropagation()
     onChange(enabled => !enabled)
@@ -25,7 +25,7 @@ function NumeroSwitch({enabled, icon, enabledHint, disabledHint, onChange}) {
   )
 }
 
-NumeroSwitch.propTypes = {
+Control.propTypes = {
   enabled: PropTypes.bool,
   icon: PropTypes.string.isRequired,
   enabledHint: PropTypes.string.isRequired,
@@ -33,8 +33,8 @@ NumeroSwitch.propTypes = {
   onChange: PropTypes.func.isRequired
 }
 
-NumeroSwitch.defaultProps = {
+Control.defaultProps = {
   enabled: true
 }
 
-export default NumeroSwitch
+export default Control

--- a/components/map/draw.js
+++ b/components/map/draw.js
@@ -1,0 +1,69 @@
+import React, {useCallback, useMemo, useContext} from 'react'
+import PropTypes from 'prop-types'
+import {Popup} from 'react-map-gl'
+import {Editor, EditingMode, DrawLineStringMode} from 'react-map-gl-draw'
+import {Text} from 'evergreen-ui'
+
+import DrawContext from '../../contexts/draw'
+
+const MODES = {
+  editing: EditingMode,
+  drawLineString: DrawLineStringMode
+}
+
+const Draw = ({hoverPos}) => {
+  const {modeId, data, hint, setHint, setData} = useContext(DrawContext)
+
+  const _onUpdate = useCallback(({data, editType}) => {
+    if (editType === 'addTentativePosition') {
+      setHint('Cliquez pour ajouter un point ou cliquez sur le dernier pour terminer la voie')
+    }
+
+    if (data) {
+      setData(data[0])
+      console.log('setData')
+    }
+  }, [setData, setHint])
+
+  const mode = useMemo(() => {
+    const Mode = MODES[modeId]
+    return Mode ? new Mode() : null
+  }, [modeId])
+
+  if (!mode) {
+    return null
+  }
+
+  return (
+    <>
+      <Editor
+        style={{width: '100%', height: '100%'}}
+        clickRadius={12}
+        mode={mode}
+        features={data ? [data] : null}
+        editHandleShape='circle'
+        onUpdate={_onUpdate}
+      />
+
+      {hoverPos && hint && (
+        <Popup {...hoverPos} closeButton={false}>
+          <Text>{hint}</Text>
+        </Popup>
+      )}
+    </>
+  )
+}
+
+Draw.defaultProps = {
+  lineVoie: null,
+  hoverPos: null
+}
+
+Draw.propTypes = {
+  lineVoie: PropTypes.array,
+  hoverPos: PropTypes.object,
+  handleVoieLine: PropTypes.func.isRequired,
+  setModeId: PropTypes.func.isRequired
+}
+
+export default Draw

--- a/components/map/draw.js
+++ b/components/map/draw.js
@@ -12,7 +12,7 @@ const MODES = {
 }
 
 const Draw = ({hoverPos}) => {
-  const {modeId, data, hint, setHint, setData} = useContext(DrawContext)
+  const {drawEnabled, modeId, data, hint, setHint, setData} = useContext(DrawContext)
 
   const _onUpdate = useCallback(({data, editType}) => {
     if (editType === 'addTentativePosition') {
@@ -30,7 +30,7 @@ const Draw = ({hoverPos}) => {
     return Mode ? new Mode() : null
   }, [modeId])
 
-  if (!mode) {
+  if (!drawEnabled || !mode) {
     return null
   }
 

--- a/components/map/draw.js
+++ b/components/map/draw.js
@@ -21,7 +21,6 @@ const Draw = ({hoverPos}) => {
 
     if (data) {
       setData(data[0])
-      console.log('setData')
     }
   }, [setData, setHint])
 
@@ -55,15 +54,11 @@ const Draw = ({hoverPos}) => {
 }
 
 Draw.defaultProps = {
-  lineVoie: null,
   hoverPos: null
 }
 
 Draw.propTypes = {
-  lineVoie: PropTypes.array,
-  hoverPos: PropTypes.object,
-  handleVoieLine: PropTypes.func.isRequired,
-  setModeId: PropTypes.func.isRequired
+  hoverPos: PropTypes.object
 }
 
 export default Draw

--- a/components/map/editable-marker.js
+++ b/components/map/editable-marker.js
@@ -7,7 +7,7 @@ import MarkerContext from '../../contexts/marker'
 import BalDataContext from '../../contexts/bal-data'
 
 function EditableMarker({viewport, size, style}) {
-  const {enabled, marker, setMarker} = useContext(MarkerContext)
+  const {enabled, marker, overrideText, setMarker} = useContext(MarkerContext)
   const {editingItem} = useContext(BalDataContext)
 
   const onDrag = useCallback(event => {
@@ -38,7 +38,7 @@ function EditableMarker({viewport, size, style}) {
       onDrag={onDrag}
     >
       <Pane>
-        {editingItem && editingItem.positions && (
+        {((editingItem && editingItem.positions) || overrideText) && (
           <Text
             position='absolute'
             top={-58}
@@ -49,7 +49,7 @@ function EditableMarker({viewport, size, style}) {
             paddingX={8}
             whiteSpace='nowrap'
           >
-            {editingItem.nom || editingItem.numeroComplet}
+            {overrideText || editingItem.nom || editingItem.numeroComplet}
           </Text>
         )}
 

--- a/components/map/editable-marker.js
+++ b/components/map/editable-marker.js
@@ -38,7 +38,7 @@ function EditableMarker({viewport, size, style}) {
       onDrag={onDrag}
     >
       <Pane>
-        {editingItem && (
+        {editingItem && editingItem.positions && (
           <Text
             position='absolute'
             top={-58}

--- a/components/map/hooks/bounds.js
+++ b/components/map/hooks/bounds.js
@@ -1,4 +1,4 @@
-import {useState, useMemo, useContext} from 'react'
+import {useMemo, useContext} from 'react'
 import bbox from '@turf/bbox'
 import buffer from '@turf/buffer'
 
@@ -7,7 +7,6 @@ import BalDataContext from '../../../contexts/bal-data'
 const BUFFER_RADIUS = 100
 
 function useBounds(commune, voie) {
-  const [currentVoie, setCurrentVoie] = useState(null)
   const {geojson} = useContext(BalDataContext)
 
   const data = useMemo(() => {
@@ -15,11 +14,6 @@ function useBounds(commune, voie) {
       let data = geojson
 
       if (voie) {
-        if (voie._id === currentVoie) {
-          return false
-        }
-
-        setCurrentVoie(voie._id)
         data = {
           type: 'FeatureCollection',
           features: data.features.filter(feature => feature.properties.idVoie === voie._id)

--- a/components/map/hooks/layers.js
+++ b/components/map/hooks/layers.js
@@ -1,18 +1,21 @@
 import {useMemo} from 'react'
 
-import {getVoiesLabelLayer, getVoieLineLayer} from '../layers/voies'
+import {getVoiesLabelLayer, getVoieTraceLayer} from '../layers/voies'
 import {getNumerosPointLayer, getNumerosLabelLayer} from '../layers/numeros'
 
 function useLayers(voie, style) {
   return useMemo(() => {
     const layers = [
       getNumerosPointLayer(style),
-      getNumerosLabelLayer()
+      getNumerosLabelLayer(),
+      getVoieTraceLayer(style)
     ]
 
-    layers.push(
-      voie ? getVoieLineLayer(style) : getVoiesLabelLayer(style)
-    )
+    if (!voie) {
+      layers.push(
+        getVoiesLabelLayer(style)
+      )
+    }
 
     return layers
   }, [voie, style])

--- a/components/map/hooks/layers.js
+++ b/components/map/hooks/layers.js
@@ -1,6 +1,6 @@
 import {useMemo} from 'react'
 
-import {getVoiesLabelLayer} from '../layers/voies'
+import {getVoiesLabelLayer, getVoieLineLayer} from '../layers/voies'
 import {getNumerosPointLayer, getNumerosLabelLayer} from '../layers/numeros'
 
 function useLayers(voie, style) {
@@ -10,11 +10,9 @@ function useLayers(voie, style) {
       getNumerosLabelLayer()
     ]
 
-    if (!voie) {
-      layers.push(
-        getVoiesLabelLayer(style)
-      )
-    }
+    layers.push(
+      voie ? getVoieLineLayer(style) : getVoiesLabelLayer(style)
+    )
 
     return layers
   }, [voie, style])

--- a/components/map/hooks/sources.js
+++ b/components/map/hooks/sources.js
@@ -34,16 +34,16 @@ function useSources(voie, hovered) {
 
     if (voie) {
       // Filter current voie’s numeros out
-      features = features.filter(({properties}) => (properties.idVoie !== voie._id) || (properties.idVoie === voie._id && properties.type === 'voie-line'))
+      features = features.filter(({properties}) => (properties.idVoie !== voie._id) || (properties.idVoie === voie._id && properties.type === 'voie-trace'))
     }
 
     features = features.map(feature => setPaintProperties(feature))
 
-    const lines = features.filter(({properties}) => properties.type === 'voie-line')
+    const lines = features.filter(({properties}) => properties.type === 'voie-trace')
 
     if (lines.length > 0) {
       sources.push({
-        name: 'voie-line',
+        name: 'voie-trace',
         data: {
           type: 'FeatureCollection',
           features: lines
@@ -56,7 +56,7 @@ function useSources(voie, hovered) {
         name: 'positions',
         data: {
           type: 'FeatureCollection',
-          features: features.filter(({properties}) => properties.type !== 'voie-line')
+          features: features.filter(({properties}) => properties.type !== 'voie-trace')
         }
       })
 

--- a/components/map/hooks/sources.js
+++ b/components/map/hooks/sources.js
@@ -56,7 +56,7 @@ function useSources(voie, hovered) {
         name: 'positions',
         data: {
           type: 'FeatureCollection',
-          features: features.filter(f => !f.lineVoie)
+          features: features.filter(({properties}) => properties.type !== 'voie-line')
         }
       })
 

--- a/components/map/hooks/sources.js
+++ b/components/map/hooks/sources.js
@@ -5,7 +5,7 @@ import randomColor from 'randomcolor'
 
 import BalDataContext from '../../../contexts/bal-data'
 
-function useSources(voie, hovered) {
+function useSources(voie, hovered, editingId) {
   const {geojson} = useContext(BalDataContext)
 
   return useMemo(() => {
@@ -39,17 +39,15 @@ function useSources(voie, hovered) {
 
     features = features.map(feature => setPaintProperties(feature))
 
-    const lines = features.filter(({properties}) => properties.type === 'voie-trace')
+    const lines = features.filter(({properties, id}) => properties.type === 'voie-trace' && id !== editingId)
 
-    if (lines.length > 0) {
-      sources.push({
-        name: 'voie-trace',
-        data: {
-          type: 'FeatureCollection',
-          features: lines
-        }
-      })
-    }
+    sources.push({
+      name: 'voie-trace',
+      data: {
+        type: 'FeatureCollection',
+        features: lines
+      }
+    })
 
     if (features.length > 0) {
       sources.push({
@@ -86,7 +84,7 @@ function useSources(voie, hovered) {
     }
 
     return sources
-  }, [geojson, voie, hovered])
+  }, [geojson, voie, hovered, editingId])
 }
 
 export default useSources

--- a/components/map/hooks/sources.js
+++ b/components/map/hooks/sources.js
@@ -10,8 +10,8 @@ function useSources(voie, hovered) {
 
   return useMemo(() => {
     const sources = []
-    const setPaintProperties = features => {
-      return features.map(feature => ({
+    const setPaintProperties = feature => {
+      return {
         ...feature,
         id: feature.properties.idNumero || feature.properties.idVoie,
         properties: {
@@ -22,7 +22,7 @@ function useSources(voie, hovered) {
             seed: feature.properties.idVoie
           })
         }
-      }))
+      }
     }
 
     if (!geojson) {
@@ -34,17 +34,29 @@ function useSources(voie, hovered) {
 
     if (voie) {
       // Filter current voie’s numeros out
-      features = features.filter(feature => feature.properties.idVoie !== voie._id)
+      features = features.filter(({properties}) => (properties.idVoie !== voie._id) || (properties.idVoie === voie._id && properties.type === 'voie-line'))
     }
 
-    features = setPaintProperties(features)
+    features = features.map(feature => setPaintProperties(feature))
+
+    const lines = features.filter(({properties}) => properties.type === 'voie-line')
+
+    if (lines.length > 0) {
+      sources.push({
+        name: 'voie-line',
+        data: {
+          type: 'FeatureCollection',
+          features: lines
+        }
+      })
+    }
 
     if (features.length > 0) {
       sources.push({
         name: 'positions',
         data: {
           type: 'FeatureCollection',
-          features
+          features: features.filter(f => !f.lineVoie)
         }
       })
 

--- a/components/map/layers/voies.js
+++ b/components/map/layers/voies.js
@@ -46,3 +46,20 @@ export function getVoiesLabelLayer(style) {
 
   return layer
 }
+
+export function getVoieLineLayer() {
+  const layer = {
+    id: 'voie-line',
+    type: 'line',
+    source: 'voie-line',
+    paint: {
+      'line-color': ['get', 'color'],
+      'line-width': 4
+    },
+    layout: {
+      'line-join': 'round'
+    }
+  }
+
+  return layer
+}

--- a/components/map/layers/voies.js
+++ b/components/map/layers/voies.js
@@ -47,11 +47,11 @@ export function getVoiesLabelLayer(style) {
   return layer
 }
 
-export function getVoieLineLayer() {
+export function getVoieTraceLayer() {
   const layer = {
-    id: 'voie-line',
+    id: 'voie-trace-line',
     type: 'line',
-    source: 'voie-line',
+    source: 'voie-trace',
     paint: {
       'line-color': ['get', 'color'],
       'line-width': 4

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -93,6 +93,7 @@ function Map({interactive, style: defaultStyle, commune, voie}) {
   const [hovered, setHovered] = useState(null)
   const [viewport, setViewport] = useState(defaultViewport)
   const [style, setStyle] = useState(defaultStyle)
+  const [editPrevStyle, setEditPrevSyle] = useState(defaultStyle)
   const [mapStyle, setMapStyle] = useState(getBaseStyle(defaultStyle))
   const [showPopover, setShowPopover] = useState(false)
 
@@ -183,6 +184,17 @@ function Map({interactive, style: defaultStyle, commune, voie}) {
       setMapStyle(getBaseStyle(interactive ? style : defaultStyle))
     }
   }, [interactive, sources, layers, style, defaultStyle])
+
+  useEffect(() => {
+    setStyle(prevStyle => {
+      if (modeId) {
+        setEditPrevSyle(prevStyle)
+        return 'ortho'
+      }
+
+      return editPrevStyle
+    })
+  }, [modeId]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (map) {

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -103,7 +103,7 @@ function Map({interactive, style: defaultStyle, commune, voie}) {
   const {enableMarker, disableMarker} = useContext(MarkerContext)
   const {token} = useContext(TokenContext)
 
-  const sources = useSources(voie, hovered)
+  const sources = useSources(voie, hovered, editingId)
   const bounds = useBounds(commune, voie)
   const layers = useLayers(voie, style)
 
@@ -301,7 +301,7 @@ function Map({interactive, style: defaultStyle, commune, voie}) {
             )}
           </Pane>
 
-          {voie && numeros && numeros.map(numero => (
+          {voie && !modeId && numeros && numeros.map(numero => (
             <NumeroMarker
               key={numero._id}
               numero={numero}

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -99,7 +99,7 @@ function Map({interactive, style: defaultStyle, commune, voie}) {
 
   const [hoverPos, setHoverPos] = useState(null)
 
-  const {baseLocale, numeros, reloadNumeros, toponymes, reloadVoies, editingId} = useContext(BalDataContext)
+  const {baseLocale, numeros, reloadNumeros, toponymes, reloadVoies, editingId, setEditingId} = useContext(BalDataContext)
   const {modeId} = useContext(DrawContext)
   const {enableMarker, disableMarker} = useContext(MarkerContext)
   const {token} = useContext(TokenContext)
@@ -121,7 +121,8 @@ function Map({interactive, style: defaultStyle, commune, voie}) {
 
     const layers = [
       'numeros-point',
-      'numeros-label'
+      'numeros-label',
+      'voie-trace-line'
     ]
 
     if (!voie) {
@@ -144,14 +145,18 @@ function Map({interactive, style: defaultStyle, commune, voie}) {
 
     if (feature && feature.properties.idVoie) {
       const {idVoie} = feature.properties
-      return Router.push(
-        `/bal/voie?balId=${baseLocale._id}&codeCommune=${commune.code}&idVoie=${idVoie}`,
-        `/bal/${baseLocale._id}/communes/${commune.code}/voies/${idVoie}`
-      )
+      if (feature.layer.id === 'voie-trace-line' && idVoie === voie._id) {
+        setEditingId(voie._id)
+      } else {
+        Router.push(
+          `/bal/voie?balId=${baseLocale._id}&codeCommune=${commune.code}&idVoie=${idVoie}`,
+          `/bal/${baseLocale._id}/communes/${commune.code}/voies/${idVoie}`
+        )
+      }
     }
 
     setShowContextMenu(null)
-  }, [baseLocale, commune])
+  }, [baseLocale, commune, setEditingId, voie])
 
   const onHover = useCallback(event => {
     const feature = event.features && event.features[0]

--- a/contexts/bal-data.js
+++ b/contexts/bal-data.js
@@ -79,9 +79,8 @@ export const BalDataContextProvider = React.memo(({balId, codeCommune, idVoie, .
 
   const editingItem = useMemo(() => {
     if (editingId) {
-      return numeros ?
-        numeros.find(numero => numero._id === editingId) :
-        voies.find(voie => voie._id === editingId)
+      const voie = voies.find(voie => voie._id === editingId)
+      return voie || numeros.find(numero => numero._id === editingId)
     }
   }, [editingId, numeros, voies])
 

--- a/contexts/bal-data.js
+++ b/contexts/bal-data.js
@@ -81,9 +81,9 @@ export const BalDataContextProvider = React.memo(({balId, codeCommune, idVoie, .
     if (editingId) {
       return numeros ?
         numeros.find(numero => numero._id === editingId) :
-        toponymes.find(toponyme => toponyme._id === editingId)
+        voies.find(voie => voie._id === editingId)
     }
-  }, [editingId, numeros, toponymes])
+  }, [editingId, numeros, voies])
 
   useEffect(() => {
     reloadGeojson()

--- a/contexts/draw.js
+++ b/contexts/draw.js
@@ -29,7 +29,11 @@ export function DrawContextProvider(props) {
     if (editingItem) {
       if (editingItem.typeNumerotation === 'metrique') {
         if (editingItem.trace) {
-          setData(editingItem.trace)
+          setData({
+            type: 'Feature',
+            properties: {},
+            geometry: editingItem.trace
+          })
           setModeId('editing')
         } else {
           setModeId('drawLineString')

--- a/contexts/draw.js
+++ b/contexts/draw.js
@@ -5,6 +5,7 @@ import BalDataContext from './bal-data'
 const DrawContext = React.createContext()
 
 export function DrawContextProvider(props) {
+  const [drawEnabled, setDrawEnabled] = useState(false)
   const [modeId, setModeId] = useState(null)
   const [hint, setHint] = useState(null)
   const [data, setData] = useState(null)
@@ -25,7 +26,7 @@ export function DrawContextProvider(props) {
   }, [data, setModeId])
 
   useEffect(() => {
-    if (editingItem) {
+    if (editingItem && editingItem.typeNumerotation === 'metric') {
       if (editingItem.lineVoie) {
         setData(editingItem.lineVoie)
         setModeId('editing')
@@ -35,9 +36,19 @@ export function DrawContextProvider(props) {
     }
   }, [editingItem])
 
+  useEffect(() => {
+    if (!drawEnabled) {
+      setData(null)
+      setModeId(null)
+    }
+  }, [drawEnabled])
+
   return (
     <DrawContext.Provider
       value={{
+        drawEnabled,
+        enableDraw: () => setDrawEnabled(true),
+        disableDraw: () => setDrawEnabled(false),
         modeId,
         setModeId,
         hint,

--- a/contexts/draw.js
+++ b/contexts/draw.js
@@ -27,7 +27,7 @@ export function DrawContextProvider(props) {
 
   useEffect(() => {
     if (editingItem) {
-      if (editingItem.typeNumerotation === 'metric') {
+      if (editingItem.typeNumerotation === 'metrique') {
         if (editingItem.trace) {
           setData(editingItem.trace)
           setModeId('editing')

--- a/contexts/draw.js
+++ b/contexts/draw.js
@@ -26,13 +26,20 @@ export function DrawContextProvider(props) {
   }, [data, setModeId])
 
   useEffect(() => {
-    if (editingItem && editingItem.typeNumerotation === 'metric') {
-      if (editingItem.trace) {
-        setData(editingItem.trace)
-        setModeId('editing')
-      } else {
-        setModeId('drawLineString')
+    if (editingItem) {
+      console.log('editingItem', editingItem)
+      if (editingItem.typeNumerotation === 'metric') {
+        console.log('editingItem.typeNumerotation', editingItem.typeNumerotation)
+        if (editingItem.trace) {
+          console.log('editingItem.trace', editingItem.trace)
+          setData(editingItem.trace)
+          setModeId('editing')
+        } else {
+          setModeId('drawLineString')
+        }
       }
+    } else {
+      setModeId(null)
     }
   }, [editingItem])
 

--- a/contexts/draw.js
+++ b/contexts/draw.js
@@ -27,11 +27,8 @@ export function DrawContextProvider(props) {
 
   useEffect(() => {
     if (editingItem) {
-      console.log('editingItem', editingItem)
       if (editingItem.typeNumerotation === 'metric') {
-        console.log('editingItem.typeNumerotation', editingItem.typeNumerotation)
         if (editingItem.trace) {
-          console.log('editingItem.trace', editingItem.trace)
           setData(editingItem.trace)
           setModeId('editing')
         } else {

--- a/contexts/draw.js
+++ b/contexts/draw.js
@@ -27,8 +27,8 @@ export function DrawContextProvider(props) {
 
   useEffect(() => {
     if (editingItem && editingItem.typeNumerotation === 'metric') {
-      if (editingItem.lineVoie) {
-        setData(editingItem.lineVoie)
+      if (editingItem.trace) {
+        setData(editingItem.trace)
         setModeId('editing')
       } else {
         setModeId('drawLineString')

--- a/contexts/draw.js
+++ b/contexts/draw.js
@@ -1,0 +1,55 @@
+import React, {useState, useEffect, useContext} from 'react'
+
+import BalDataContext from './bal-data'
+
+const DrawContext = React.createContext()
+
+export function DrawContextProvider(props) {
+  const [modeId, setModeId] = useState(null)
+  const [hint, setHint] = useState(null)
+  const [data, setData] = useState(null)
+
+  const {editingItem} = useContext(BalDataContext)
+
+  useEffect(() => {
+    if (modeId === 'drawLineString') {
+      setHint('Indiquez le début de la voie')
+    }
+  }, [modeId])
+
+  useEffect(() => {
+    if (data) {
+      setHint(null)
+      setModeId('editing')
+    }
+  }, [data, setModeId])
+
+  useEffect(() => {
+    if (editingItem) {
+      if (editingItem.lineVoie) {
+        setData(editingItem.lineVoie)
+        setModeId('editing')
+      } else {
+        setModeId('drawLineString')
+      }
+    }
+  }, [editingItem])
+
+  return (
+    <DrawContext.Provider
+      value={{
+        modeId,
+        setModeId,
+        hint,
+        setHint,
+        data,
+        setData
+      }}
+      {...props}
+    />
+  )
+}
+
+export const DrawContextConsumer = DrawContext.Consumer
+
+export default DrawContext

--- a/contexts/marker.js
+++ b/contexts/marker.js
@@ -7,17 +7,23 @@ const MarkerContext = React.createContext()
 export function MarkerContextProvider(props) {
   const [enabled, setEnabled] = useState(false)
   const [marker, setMarker] = useState(null)
+  const [overrideText, setOverrideText] = useState(null)
 
   const {editingId} = useContext(BalDataContext)
+
+  const disableMarker = useCallback(() => {
+    setEnabled(false)
+    setMarker(null)
+    setOverrideText(null)
+  }, [])
 
   useEffect(() => {
     if (editingId) {
       setEnabled(true)
     } else {
-      setEnabled(false)
-      setMarker(null)
+      disableMarker()
     }
-  }, [editingId])
+  }, [disableMarker, editingId])
 
   const enableMarker = useCallback(defaultValue => {
     if (defaultValue) {
@@ -30,18 +36,15 @@ export function MarkerContextProvider(props) {
     setEnabled(true)
   }, [])
 
-  const disableMarker = useCallback(() => {
-    setEnabled(false)
-    setMarker(null)
-  }, [])
-
   return (
     <MarkerContext.Provider
       value={{
         enabled,
         marker,
+        overrideText,
         setMarker,
         enableMarker,
+        setOverrideText,
         disableMarker
       }}
       {...props}

--- a/lib/voie.js
+++ b/lib/voie.js
@@ -6,3 +6,10 @@ export function getFullVoieName(voie, isComplementEnable = false) {
 
   return nom
 }
+
+export function checkIsToponyme(voie) {
+  const {positions, isMetric} = voie || {}
+  const position = positions ? positions[0] : null
+
+  return Boolean(position && !isMetric)
+}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "react": "^16.10.2",
     "react-dom": "^16.10.2",
     "react-dropzone": "^10.1.10",
-    "react-map-gl": "^5.0.11",
+    "react-map-gl": "^5.2.7",
     "use-debounce": "^1.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@turf/buffer": "^5.1.5",
     "@turf/centroid": "^6.0.2",
     "@turf/difference": "6.0.1",
+    "@turf/distance": "^6.0.1",
     "babel-plugin-lodash": "^3.3.4",
     "compression": "^1.7.4",
     "evergreen-ui": "^4.19.3",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@turf/bbox": "^6.0.1",
     "@turf/buffer": "^5.1.5",
     "@turf/centroid": "^6.0.2",
+    "@turf/difference": "6.0.1",
     "babel-plugin-lodash": "^3.3.4",
     "compression": "^1.7.4",
     "evergreen-ui": "^4.19.3",
@@ -29,6 +30,7 @@
     "react-dom": "^16.10.2",
     "react-dropzone": "^10.1.10",
     "react-map-gl": "^5.2.7",
+    "react-map-gl-draw": "^0.19.2",
     "use-debounce": "^1.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "@turf/centroid": "^6.0.2",
     "@turf/difference": "6.0.1",
     "@turf/distance": "^6.0.1",
+    "@turf/nearest-point-on-line": "^6.0.2",
+    "@turf/rhumb-distance": "^6.0.1",
     "babel-plugin-lodash": "^3.3.4",
     "compression": "^1.7.4",
     "evergreen-ui": "^4.19.3",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -17,6 +17,7 @@ import Help from '../components/help'
 
 import {HelpContextProvider} from '../contexts/help'
 import {SettingsContextProvider} from '../contexts/settings'
+import {DrawContextProvider} from '../contexts/draw'
 import {MarkerContextProvider} from '../contexts/marker'
 import {TokenContextProvider} from '../contexts/token'
 import {BalDataContextProvider} from '../contexts/bal-data'
@@ -87,53 +88,55 @@ function App({error, Component, pageProps, query}) {
 
       <TokenContextProvider balId={query.balId} token={query.token}>
         <BalDataContextProvider balId={query.balId} codeCommune={query.codeCommune} idVoie={query.idVoie}>
-          <MarkerContextProvider>
-            <HelpContextProvider>
+          <DrawContextProvider>
+            <MarkerContextProvider>
+              <HelpContextProvider>
 
-              <Help />
+                <Help />
 
-              {pageProps.baseLocale && (
-                <SettingsContextProvider>
-                  <Settings nomBaseLocale={pageProps.baseLocale.nom} isEnabledComplement={pageProps.baseLocale.enableComplement} />
-                  <Header
-                    {...pageProps}
-                    layout={layout}
-                    isSidebarHidden={isHidden}
-                    onToggle={onToggle}
-                  />
-                </SettingsContextProvider>
-              )}
-
-              <Map
-                top={topOffset}
-                left={leftOffset}
-                animate={layout === 'sidebar'}
-                interactive={layout === 'sidebar'}
-                commune={pageProps.commune}
-                voie={pageProps.voie}
-              />
-
-              <Wrapper
-                top={topOffset}
-                isHidden={isHidden}
-                size={500}
-                elevation={2}
-                background='tint2'
-                display='flex'
-                flexDirection='column'
-                onToggle={onToggle}
-              >
-                {error ? (
-                  <ErrorPage statusCode={error.statusCode} />
-                ) : (
-                  <>
-                    <IEWarning />
-                    <Component {...otherPageProps} />
-                  </>
+                {pageProps.baseLocale && (
+                  <SettingsContextProvider>
+                    <Settings nomBaseLocale={pageProps.baseLocale.nom} isEnabledComplement={pageProps.baseLocale.enableComplement} />
+                    <Header
+                      {...pageProps}
+                      layout={layout}
+                      isSidebarHidden={isHidden}
+                      onToggle={onToggle}
+                    />
+                  </SettingsContextProvider>
                 )}
-              </Wrapper>
-            </HelpContextProvider>
-          </MarkerContextProvider>
+
+                <Map
+                  top={topOffset}
+                  left={leftOffset}
+                  animate={layout === 'sidebar'}
+                  interactive={layout === 'sidebar'}
+                  commune={pageProps.commune}
+                  voie={pageProps.voie}
+                />
+
+                <Wrapper
+                  top={topOffset}
+                  isHidden={isHidden}
+                  size={500}
+                  elevation={2}
+                  background='tint2'
+                  display='flex'
+                  flexDirection='column'
+                  onToggle={onToggle}
+                >
+                  {error ? (
+                    <ErrorPage statusCode={error.statusCode} />
+                  ) : (
+                    <>
+                      <IEWarning />
+                      <Component {...otherPageProps} />
+                    </>
+                  )}
+                </Wrapper>
+              </HelpContextProvider>
+            </MarkerContextProvider>
+          </DrawContextProvider>
         </BalDataContextProvider>
       </TokenContextProvider>
     </Container>

--- a/pages/bal/commune.js
+++ b/pages/bal/commune.js
@@ -24,9 +24,9 @@ const Commune = React.memo(({commune, defaultVoies}) => {
   const [toRemove, setToRemove] = useState(null)
 
   const {token} = useContext(TokenContext)
-  const {baseLocale} = useContext(BalDataContext)
 
   const {
+    baseLocale,
     voies,
     reloadVoies,
     editingId,

--- a/pages/bal/commune.js
+++ b/pages/bal/commune.js
@@ -49,16 +49,16 @@ const Commune = React.memo(({commune, defaultVoies}) => {
     setIsPopulating(false)
   }, [baseLocale, commune, reloadVoies, token])
 
-  const onAdd = useCallback(async ({nom, positions, typeNumerotation, lineVoie, complement}) => {
+  const onAdd = useCallback(async ({nom, positions, typeNumerotation, trace, complement}) => {
     const voie = await addVoie(baseLocale._id, commune.code, {
       nom,
       typeNumerotation,
       positions,
-      lineVoie,
+      trace,
       complement
     }, token)
 
-    if (lineVoie) {
+    if (trace) {
       Router.push(
         `/bal/voie?balId=${baseLocale._id}&codeCommune=${commune.code}&idVoie=${voie._id}`,
         `/bal/${baseLocale._id}/communes/${commune.code}/voies/${voie._id}`
@@ -79,11 +79,11 @@ const Commune = React.memo(({commune, defaultVoies}) => {
     setEditingId(idVoie)
   }, [setEditingId])
 
-  const onEdit = useCallback(async ({nom, typeNumerotation, lineVoie, positions, complement}) => {
+  const onEdit = useCallback(async ({nom, typeNumerotation, trace, positions, complement}) => {
     await editVoie(editingId, {
       nom,
       typeNumerotation,
-      lineVoie,
+      trace,
       positions,
       complement
     }, token)

--- a/pages/bal/commune.js
+++ b/pages/bal/commune.js
@@ -49,10 +49,11 @@ const Commune = React.memo(({commune, defaultVoies}) => {
     setIsPopulating(false)
   }, [baseLocale, commune, reloadVoies, token])
 
-  const onAdd = useCallback(async ({nom, positions, complement}) => {
+  const onAdd = useCallback(async ({nom, positions, lineVoie, complement}) => {
     await addVoie(baseLocale._id, commune.code, {
       nom,
       positions,
+      lineVoie,
       complement
     }, token)
 
@@ -70,9 +71,11 @@ const Commune = React.memo(({commune, defaultVoies}) => {
     setEditingId(idVoie)
   }, [setEditingId])
 
-  const onEdit = useCallback(async ({nom, positions, complement}) => {
+  const onEdit = useCallback(async ({nom, typeNumerotation, lineVoie, positions, complement}) => {
     await editVoie(editingId, {
       nom,
+      typeNumerotation,
+      lineVoie,
       positions,
       complement
     }, token)

--- a/pages/bal/commune.js
+++ b/pages/bal/commune.js
@@ -49,15 +49,23 @@ const Commune = React.memo(({commune, defaultVoies}) => {
     setIsPopulating(false)
   }, [baseLocale, commune, reloadVoies, token])
 
-  const onAdd = useCallback(async ({nom, positions, lineVoie, complement}) => {
-    await addVoie(baseLocale._id, commune.code, {
+  const onAdd = useCallback(async ({nom, positions, typeNumerotation, lineVoie, complement}) => {
+    const voie = await addVoie(baseLocale._id, commune.code, {
       nom,
+      typeNumerotation,
       positions,
       lineVoie,
       complement
     }, token)
 
-    await reloadVoies()
+    if (lineVoie) {
+      Router.push(
+        `/bal/voie?balId=${baseLocale._id}&codeCommune=${commune.code}&idVoie=${voie._id}`,
+        `/bal/${baseLocale._id}/communes/${commune.code}/voies/${voie._id}`
+      )
+    } else {
+      await reloadVoies()
+    }
 
     setIsAdding(false)
   }, [baseLocale, commune, reloadVoies, token])

--- a/pages/bal/commune.js
+++ b/pages/bal/commune.js
@@ -63,9 +63,9 @@ const Commune = React.memo(({commune, defaultVoies}) => {
         `/bal/voie?balId=${baseLocale._id}&codeCommune=${commune.code}&idVoie=${voie._id}`,
         `/bal/${baseLocale._id}/communes/${commune.code}/voies/${voie._id}`
       )
-    } else {
-      await reloadVoies()
     }
+
+    await reloadVoies()
 
     setIsAdding(false)
   }, [baseLocale, commune, reloadVoies, token])

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -203,6 +203,7 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
               <Table.Row height='auto'>
                 <Table.Cell borderBottom display='block' paddingY={12} background='tint1'>
                   <NumeroEditor
+                    initialVoie={voie}
                     onSubmit={onAdd}
                     onCancel={onCancel}
                   />
@@ -220,6 +221,7 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
               <Table.Row height='auto'>
                 <Table.Cell display='block' paddingY={12} background='tint1'>
                   <NumeroEditor
+                    initialVoie={voie}
                     initialValue={editedNumero}
                     onSubmit={onEdit}
                     onCancel={onCancel}

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -57,11 +57,11 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
     setIsAdding(false)
   }, [voie, reloadNumeros, token])
 
-  const onEditVoie = useCallback(async ({nom, typeNumerotation, lineVoie, complement, positions}) => {
+  const onEditVoie = useCallback(async ({nom, typeNumerotation, trace, complement, positions}) => {
     const editedVoie = await editVoie(voie._id, {
       nom,
       typeNumerotation,
-      lineVoie,
+      trace,
       complement,
       positions
     }, token)

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -66,10 +66,11 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
       positions
     }, token)
 
+    setEditingId(null)
     await reloadVoies()
 
     setEditedVoie(editedVoie)
-  }, [reloadVoies, token, voie])
+  }, [reloadVoies, setEditingId, token, voie])
 
   const onEnableAdding = useCallback(() => {
     setIsAdding(true)

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -17,7 +17,7 @@ import VoieEditor from '../../components/bal/voie-editor'
 import NumeroEditor from '../../components/bal/numero-editor'
 
 const Voie = React.memo(({voie, defaultNumeros}) => {
-  const [editedVoie, setEditedVoie] = useState(null)
+  const [editedVoie, setEditedVoie] = useState(voie)
   const [isEdited, setEdited] = useState(false)
   const [hovered, setHovered] = useState(false)
   const [isAdding, setIsAdding] = useState(false)
@@ -69,8 +69,6 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
     await reloadVoies()
 
     setEditedVoie(editedVoie)
-
-    setEdited(false)
   }, [reloadVoies, token, voie])
 
   const onEnableAdding = useCallback(() => {
@@ -81,6 +79,11 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
     setIsAdding(false)
     setEditingId(idNumero)
   }, [setEditingId])
+
+  const onEnableVoieEditing = useCallback(() => {
+    setEditingId(voie._id)
+    setHovered(false)
+  }, [setEditingId, voie._id])
 
   const onEdit = useCallback(async ({numero, voie, suffixe, comment, positions}) => {
     await editNumero(editingId, {
@@ -132,20 +135,17 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
         background='tint1'
         padding={16}
       >
-        {isEdited ? (
+        {editingId === voie._id ? (
           <VoieEditor
             initialValue={{...currentVoie}}
             isEnabledComplement={Boolean(baseLocale.enableComplement)}
             onSubmit={onEditVoie}
-            onCancel={() => setEdited(false)}
+            onCancel={() => setEditingId(null)}
           />
         ) : (
           <Heading
             style={{cursor: hovered ? 'text' : 'default'}}
-            onClick={() => {
-              setEdited(true)
-              setHovered(false)
-            }}
+            onClick={onEnableVoieEditing}
             onMouseEnter={() => setHovered(true)}
             onMouseLeave={() => setHovered(false)}
           >
@@ -216,7 +216,7 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
                 </Table.TextCell>
               </Table.Row>
             )}
-            {editingId ? (
+            {editingId && editingId !== voie._id ? (
               <Table.Row height='auto'>
                 <Table.Cell display='block' paddingY={12} background='tint1'>
                   <NumeroEditor

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -57,9 +57,11 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
     setIsAdding(false)
   }, [voie, reloadNumeros, token])
 
-  const onEditVoie = useCallback(async ({nom, complement, positions}) => {
+  const onEditVoie = useCallback(async ({nom, typeNumerotation, lineVoie, complement, positions}) => {
     const editedVoie = await editVoie(voie._id, {
       nom,
+      typeNumerotation,
+      lineVoie,
       complement,
       positions
     }, token)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1014,6 +1014,38 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
+"@nebula.gl/edit-modes@0.19.2":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@nebula.gl/edit-modes/-/edit-modes-0.19.2.tgz#fd22c0a6dc3daa62e8d6ac6eaed610ec8f72b361"
+  integrity sha512-E2Si7vqM1PhCyOhPGxAcgM4NLnMf4H3pLmd/H4VW5X/N496Y8orY3Zahvq4eZwLHL2897lAyk4A52RTGhx4Afg==
+  dependencies:
+    "@turf/bbox" ">=4.0.0"
+    "@turf/bbox-polygon" ">=4.0.0"
+    "@turf/bearing" ">=4.0.0"
+    "@turf/boolean-point-in-polygon" ">=4.0.0"
+    "@turf/buffer" ">=4.0.0"
+    "@turf/center" ">=4.0.0"
+    "@turf/centroid" ">=4.0.0"
+    "@turf/circle" ">=4.0.0"
+    "@turf/destination" ">=4.0.0"
+    "@turf/difference" ">=4.0.0"
+    "@turf/distance" ">=4.0.0"
+    "@turf/ellipse" ">=4.0.0"
+    "@turf/helpers" ">=4.0.0"
+    "@turf/intersect" ">=4.0.0"
+    "@turf/line-intersect" ">=4.0.0"
+    "@turf/nearest-point-on-line" ">=4.0.0"
+    "@turf/point-to-line-distance" ">=4.0.0"
+    "@turf/polygon-to-line" ">=4.0.0"
+    "@turf/rewind" ">=4.0.0"
+    "@turf/transform-rotate" ">=4.0.0"
+    "@turf/transform-scale" ">=4.0.0"
+    "@turf/transform-translate" ">=4.0.0"
+    "@turf/union" ">=4.0.0"
+    geojson "0.5.0"
+    lodash.throttle "^4.1.1"
+    viewport-mercator-project ">=6.0.0"
+
 "@nodelib/fs.stat@^1.1.2":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
@@ -1024,6 +1056,29 @@
   resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.2.0.tgz#97f9e48fe736aa5c6f4f32cf73c1f19d005f8550"
   integrity sha512-lVK/svL2HuQdp7jgvlrLkFsUx50Az9chAhxpiPwBqcS83I2pVWvXp98FOcSCCJCV++l115QmzHhFd+ycw1zLBg==
 
+"@turf/area@6.x":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@turf/area/-/area-6.0.1.tgz#50ed63c70ef2bdb72952384f1594319d94f3b051"
+  integrity sha512-Zv+3N1ep9P5JvR0YOYagLANyapGWQBh8atdeR3bKpWcigVXFsEKNUw03U/5xnh+cKzm7yozHD6MFJkqQv55y0g==
+  dependencies:
+    "@turf/helpers" "6.x"
+    "@turf/meta" "6.x"
+
+"@turf/bbox-polygon@>=4.0.0":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@turf/bbox-polygon/-/bbox-polygon-6.0.1.tgz#ae0fbb14558831fb34538aae089a23d3336c6379"
+  integrity sha512-f6BK6GOzUNjmJeOYHklk/5LNcQMQbo51gvAM10dTM5IqzKP01KM5bgV88uOKfSZB0HRQVpaRV1tgXk2bg5cPRg==
+  dependencies:
+    "@turf/helpers" "6.x"
+
+"@turf/bbox@*", "@turf/bbox@6.x", "@turf/bbox@>=4.0.0", "@turf/bbox@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@turf/bbox/-/bbox-6.0.1.tgz#b966075771475940ee1c16be2a12cf389e6e923a"
+  integrity sha512-EGgaRLettBG25Iyx7VyUINsPpVj1x3nFQFiGS3ER8KCI1MximzNLsam3eXRabqQDjyAKyAE1bJ4EZEpGvspQxw==
+  dependencies:
+    "@turf/helpers" "6.x"
+    "@turf/meta" "6.x"
+
 "@turf/bbox@^5.1.5":
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/@turf/bbox/-/bbox-5.1.5.tgz#3051df514ad4c50f4a4f9b8a2d15fd8b6840eda3"
@@ -1032,15 +1087,31 @@
     "@turf/helpers" "^5.1.5"
     "@turf/meta" "^5.1.5"
 
-"@turf/bbox@^6.0.1":
+"@turf/bearing@6.x", "@turf/bearing@>=4.0.0":
   version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@turf/bbox/-/bbox-6.0.1.tgz#b966075771475940ee1c16be2a12cf389e6e923a"
-  integrity sha512-EGgaRLettBG25Iyx7VyUINsPpVj1x3nFQFiGS3ER8KCI1MximzNLsam3eXRabqQDjyAKyAE1bJ4EZEpGvspQxw==
+  resolved "https://registry.yarnpkg.com/@turf/bearing/-/bearing-6.0.1.tgz#8da5d17092e571f170cde7bfb2e5b0d74923c92d"
+  integrity sha512-mXY1NozqV9EFfBTbUItujwfqfQF0G/Xe2fzvnZle90ekPEUfhi4Dgf5JswJTd96J9LiT8kcd6Jonp5khnx0wIg==
   dependencies:
     "@turf/helpers" "6.x"
-    "@turf/meta" "6.x"
+    "@turf/invariant" "6.x"
 
-"@turf/buffer@^5.1.5":
+"@turf/boolean-clockwise@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz#3302b7dac62c5e291a0789e29af7283387fa9deb"
+  integrity sha1-MwK32sYsXikaB4nimvcoM4f6nes=
+  dependencies:
+    "@turf/helpers" "^5.1.5"
+    "@turf/invariant" "^5.1.5"
+
+"@turf/boolean-point-in-polygon@>=4.0.0":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.0.1.tgz#5836677afd77d2ee391af0056a0c29b660edfa32"
+  integrity sha512-FKLOZ124vkJhjzNSDcqpwp2NvfnsbYoUOt5iAE7uskt4svix5hcjIEgX9sELFTJpbLGsD1mUbKdfns8tZxcMNg==
+  dependencies:
+    "@turf/helpers" "6.x"
+    "@turf/invariant" "6.x"
+
+"@turf/buffer@>=4.0.0", "@turf/buffer@^5.1.5":
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/@turf/buffer/-/buffer-5.1.5.tgz#841c9627cfb974b122ac4e1a956f0466bc0231c4"
   integrity sha1-hByWJ8+5dLEirE4alW8EZrwCMcQ=
@@ -1053,6 +1124,14 @@
     d3-geo "1.7.1"
     turf-jsts "*"
 
+"@turf/center@>=4.0.0":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@turf/center/-/center-6.0.1.tgz#40a17d0a170df5bba09ad93e133b904d8eb14601"
+  integrity sha512-bh/SLBwRC2QYcbVOxMFBtiARuMzMzfh4YuVtguYAjyBEIA4HXnnEZT+yZlzfcG3oikG7XgV8vg9eegcmwQe+MQ==
+  dependencies:
+    "@turf/bbox" "6.x"
+    "@turf/helpers" "6.x"
+
 "@turf/center@^5.1.5":
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/@turf/center/-/center-5.1.5.tgz#44ab2cd954f63c0d37757f7158a99c3ef5114b80"
@@ -1061,13 +1140,36 @@
     "@turf/bbox" "^5.1.5"
     "@turf/helpers" "^5.1.5"
 
-"@turf/centroid@^6.0.2":
+"@turf/centroid@>=4.0.0", "@turf/centroid@^6.0.2":
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/@turf/centroid/-/centroid-6.0.2.tgz#c4eb16b4bc60b692f74e1809cf9a7c4a4f5ba1cc"
   integrity sha512-auyDauOtC4eddH7GC3CHFTDu2PKhpSeKCRhwhHhXtJqn2dWCJQNIoCeJRmfXRIbzCWhWvgvQafvvhq8HNvmvWw==
   dependencies:
     "@turf/helpers" "6.x"
     "@turf/meta" "6.x"
+
+"@turf/centroid@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/centroid/-/centroid-5.1.5.tgz#778ada74216335021ad8fd0e7a65a8349d53c769"
+  integrity sha1-d4radCFjNQIa2P0OemWoNJ1Tx2k=
+  dependencies:
+    "@turf/helpers" "^5.1.5"
+    "@turf/meta" "^5.1.5"
+
+"@turf/circle@>=4.0.0":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@turf/circle/-/circle-6.0.1.tgz#0ab72083373ae3c76b700c17a504ab1b5c0910b9"
+  integrity sha512-pF9XsYtCvY9ZyNqJ3hFYem9VaiGdVNQb0SFq/zzDMwH3iWZPPJQHnnDB/3e8RD1VDtBBov9p5uO2k7otsfezjw==
+  dependencies:
+    "@turf/destination" "6.x"
+    "@turf/helpers" "6.x"
+
+"@turf/clone@6.x":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@turf/clone/-/clone-6.0.2.tgz#7563cebbb3e2e19f361599bb244467e0dcc205c9"
+  integrity sha512-UVpYPnW3wRj3bPncR6Z2PRbowBk+nEdVWgGewPxrKKLfvswtVtG9n/OIyvbU3E3ZOadBVxTH2uAMEMOz4800FA==
+  dependencies:
+    "@turf/helpers" "6.x"
 
 "@turf/clone@^5.1.5":
   version "5.1.5"
@@ -1076,7 +1178,44 @@
   dependencies:
     "@turf/helpers" "^5.1.5"
 
-"@turf/helpers@6.x":
+"@turf/destination@6.x", "@turf/destination@>=4.0.0":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@turf/destination/-/destination-6.0.1.tgz#5275887fa96ec463f44864a2c17f0b712361794a"
+  integrity sha512-MroK4nRdp7as174miCAugp8Uvorhe6rZ7MJiC9Hb4+hZR7gNFJyVKmkdDDXIoCYs6MJQsx0buI+gsCpKwgww0Q==
+  dependencies:
+    "@turf/helpers" "6.x"
+    "@turf/invariant" "6.x"
+
+"@turf/difference@6.0.1", "@turf/difference@>=4.0.0":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@turf/difference/-/difference-6.0.1.tgz#a5ee3433eddb7d707cac227adf0d43ab0d651682"
+  integrity sha512-lkhJjNfPeLARQm232A851vVhrUvX3gdvTft5QlqkUlr7AzLpiT8PW14yEkU9xABxRh6PGv7T1UUVAeRgC7JxuA==
+  dependencies:
+    "@turf/area" "6.x"
+    "@turf/helpers" "6.x"
+    "@turf/invariant" "6.x"
+    "@turf/meta" "6.x"
+    martinez-polygon-clipping "*"
+
+"@turf/distance@6.x", "@turf/distance@>=4.0.0":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@turf/distance/-/distance-6.0.1.tgz#0761f28784286e7865a427c4e7e3593569c2dea8"
+  integrity sha512-q7t7rWIWfkg7MP1Vt4uLjSEhe5rPfCO2JjpKmk7JC+QZKEQkuvHEqy3ejW1iC7Kw5ZcZNR3qdMGGz+6HnVwqvg==
+  dependencies:
+    "@turf/helpers" "6.x"
+    "@turf/invariant" "6.x"
+
+"@turf/ellipse@>=4.0.0":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/ellipse/-/ellipse-5.1.5.tgz#d57cab853985920cde60228a78d80458025c54be"
+  integrity sha1-1XyrhTmFkgzeYCKKeNgEWAJcVL4=
+  dependencies:
+    "@turf/helpers" "^5.1.5"
+    "@turf/invariant" "^5.1.5"
+    "@turf/rhumb-destination" "^5.1.5"
+    "@turf/transform-rotate" "^5.1.5"
+
+"@turf/helpers@6.x", "@turf/helpers@>=4.0.0", "@turf/helpers@^6.1.4":
   version "6.1.4"
   resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-6.1.4.tgz#d6fd7ebe6782dd9c87dca5559bda5c48ae4c3836"
   integrity sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g==
@@ -1085,6 +1224,49 @@
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-5.1.5.tgz#153405227ab933d004a5bb9641a9ed999fcbe0cf"
   integrity sha1-FTQFInq5M9AEpbuWQantmZ/L4M8=
+
+"@turf/intersect@>=4.0.0":
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/@turf/intersect/-/intersect-6.1.3.tgz#c6574a2f00a38df6f81fc08d8103ad5295b7b6bc"
+  integrity sha512-SeAJG/zPRRTeyK2OifkPoyLq60q8tv8prpPIH3R8ZhyF4MdLOnMv5MURaQ6kQd+3UTDrL+pYm6rqbPvln1zqIw==
+  dependencies:
+    "@turf/helpers" "6.x"
+    "@turf/invariant" "6.x"
+    martinez-polygon-clipping "^0.4.3"
+
+"@turf/invariant@6.x":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-6.1.2.tgz#6013ed6219f9ac2edada9b31e1dfa5918eb0a2f7"
+  integrity sha512-WU08Ph8j0J2jVGlQCKChXoCtI50BB3yEH21V++V0T4cR1T27HKCxkehV2sYMwTierfMBgjwSwDIsxnR4/2mWXg==
+  dependencies:
+    "@turf/helpers" "6.x"
+
+"@turf/invariant@^5.1.5":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-5.2.0.tgz#f0150ff7290b38577b73d088b7932c1ee0aa90a7"
+  integrity sha1-8BUP9ykLOFd7c9CIt5MsHuCqkKc=
+  dependencies:
+    "@turf/helpers" "^5.1.5"
+
+"@turf/line-intersect@6.x", "@turf/line-intersect@>=4.0.0":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@turf/line-intersect/-/line-intersect-6.0.2.tgz#b45b7a4e7e08c39a0e4e91099580ed377ef7335f"
+  integrity sha512-pfL/lBu7ukBPdTjvSCmcNUzZ83V4R95htwqs5NqU8zeS4R+5KTwacbrOYKztjpmHBwUmPEIIpSbqkUoD0Fp7kg==
+  dependencies:
+    "@turf/helpers" "6.x"
+    "@turf/invariant" "6.x"
+    "@turf/line-segment" "6.x"
+    "@turf/meta" "6.x"
+    geojson-rbush "3.x"
+
+"@turf/line-segment@6.x":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@turf/line-segment/-/line-segment-6.0.2.tgz#e280bcde70d28b694028ec1623dc406c928e59b6"
+  integrity sha512-8AkzDHoNw3X68y115josal+lvdAi4b2P1K0YNTKGyLRBaUhPXVSuMBpMd53FRF1hYEb9UJgMbugF9ZE7m5L6zg==
+  dependencies:
+    "@turf/helpers" "6.x"
+    "@turf/invariant" "6.x"
+    "@turf/meta" "6.x"
 
 "@turf/meta@6.x":
   version "6.0.2"
@@ -1100,6 +1282,50 @@
   dependencies:
     "@turf/helpers" "^5.1.5"
 
+"@turf/nearest-point-on-line@>=4.0.0":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@turf/nearest-point-on-line/-/nearest-point-on-line-6.0.2.tgz#4b2c1177595d9a1743af76905a9013ced03bc0dc"
+  integrity sha512-re9tSEwYyG1EMo4ObXXAKYVhkMVANPIIJQ1V/J1lKcNfHVc1pYmd3D5jkTNBh+oriI9VL4PVML3eqYE+Zcg0mg==
+  dependencies:
+    "@turf/bearing" "6.x"
+    "@turf/destination" "6.x"
+    "@turf/distance" "6.x"
+    "@turf/helpers" "6.x"
+    "@turf/invariant" "6.x"
+    "@turf/line-intersect" "6.x"
+    "@turf/meta" "6.x"
+
+"@turf/point-to-line-distance@>=4.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@turf/point-to-line-distance/-/point-to-line-distance-6.0.0.tgz#e2f59177273a5f2a9e7fa8d2c054bae7da815ccf"
+  integrity sha512-2UuZFtn8MRfrqBHSqkrH/jm5q/VedyL7a4YC50Nd5FqXs5TgmAB7ms2igSbCkyaOtRypGhMl9fun3Hg5PIVRMQ==
+  dependencies:
+    "@turf/bearing" "6.x"
+    "@turf/distance" "6.x"
+    "@turf/helpers" "6.x"
+    "@turf/invariant" "6.x"
+    "@turf/meta" "6.x"
+    "@turf/projection" "6.x"
+    "@turf/rhumb-bearing" "6.x"
+    "@turf/rhumb-distance" "6.x"
+
+"@turf/polygon-to-line@>=4.0.0":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/@turf/polygon-to-line/-/polygon-to-line-6.0.3.tgz#a7c5416f61651d5d25ff51ee006522725cb1adf1"
+  integrity sha512-cJUy7VYLAhgnTBOtYFjNzh5bSlAS/qM8gUHXRGrIxI22RUJk4FXs/X2MEJ4Ki2flCiSeOjRIUEawEslNe7w7RA==
+  dependencies:
+    "@turf/helpers" "6.x"
+    "@turf/invariant" "6.x"
+
+"@turf/projection@6.x":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@turf/projection/-/projection-6.0.1.tgz#bde70ae8441b9cefddf26d71c7db74bc3d9792b1"
+  integrity sha512-Y3RvGT6I53MjYKLG69e9sMk45wJXcLbrEO1t6P3WQQQGqA2gYhhMJyV41vE2Z2llrJpvs2dDx/tIeQzGd0HHMQ==
+  dependencies:
+    "@turf/clone" "6.x"
+    "@turf/helpers" "6.x"
+    "@turf/meta" "6.x"
+
 "@turf/projection@^5.1.5":
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/@turf/projection/-/projection-5.1.5.tgz#24517eeeb2f36816ba9f712e7ae6d6a368edf757"
@@ -1108,6 +1334,149 @@
     "@turf/clone" "^5.1.5"
     "@turf/helpers" "^5.1.5"
     "@turf/meta" "^5.1.5"
+
+"@turf/rewind@>=4.0.0":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/rewind/-/rewind-5.1.5.tgz#9ea3db4a68b73c1fd1dd11f57631b143cfefa1c9"
+  integrity sha1-nqPbSmi3PB/R3RH1djGxQ8/vock=
+  dependencies:
+    "@turf/boolean-clockwise" "^5.1.5"
+    "@turf/clone" "^5.1.5"
+    "@turf/helpers" "^5.1.5"
+    "@turf/invariant" "^5.1.5"
+    "@turf/meta" "^5.1.5"
+
+"@turf/rhumb-bearing@6.x":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@turf/rhumb-bearing/-/rhumb-bearing-6.0.1.tgz#182c4c21fe951e097fb468ae128dc22ef6078f3f"
+  integrity sha512-MVBra8OVfjM4+/N0B3o6cBIYg9p/uRKzA9uk05RfrzasEbUL1vdD23LkTooVL74Yw4UxL8BQD9hS5Re2COJFDA==
+  dependencies:
+    "@turf/helpers" "6.x"
+    "@turf/invariant" "6.x"
+
+"@turf/rhumb-bearing@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz#acf6a502427eb8c49e18cda6ae0effab0c5ddcd2"
+  integrity sha1-rPalAkJ+uMSeGM2mrg7/qwxd3NI=
+  dependencies:
+    "@turf/helpers" "^5.1.5"
+    "@turf/invariant" "^5.1.5"
+
+"@turf/rhumb-destination@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/rhumb-destination/-/rhumb-destination-5.1.5.tgz#b1b2aeb921547f2ac0c1a994b6a130f92463c742"
+  integrity sha1-sbKuuSFUfyrAwamUtqEw+SRjx0I=
+  dependencies:
+    "@turf/helpers" "^5.1.5"
+    "@turf/invariant" "^5.1.5"
+
+"@turf/rhumb-distance@6.x":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@turf/rhumb-distance/-/rhumb-distance-6.0.1.tgz#ae1c5c823b4b04f75cd7fc240f7f93647db8bdd4"
+  integrity sha512-3G45DQtQByzzfHFPcCyJdUZFwsd45zfZ7sAb1ddF7mhEj4G70+T2G3GKjInymqDNrbyh2gbG6wQiZSToC8Uf9g==
+  dependencies:
+    "@turf/helpers" "6.x"
+    "@turf/invariant" "6.x"
+
+"@turf/rhumb-distance@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz#1806857625f4225384dad413e69f39538ff5f765"
+  integrity sha1-GAaFdiX0IlOE2tQT5p85U4/192U=
+  dependencies:
+    "@turf/helpers" "^5.1.5"
+    "@turf/invariant" "^5.1.5"
+
+"@turf/transform-rotate@>=4.0.0", "@turf/transform-rotate@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/transform-rotate/-/transform-rotate-5.1.5.tgz#d096edd9e300fe315069d54d8e458c409221edfb"
+  integrity sha1-0Jbt2eMA/jFQadVNjkWMQJIh7fs=
+  dependencies:
+    "@turf/centroid" "^5.1.5"
+    "@turf/clone" "^5.1.5"
+    "@turf/helpers" "^5.1.5"
+    "@turf/invariant" "^5.1.5"
+    "@turf/meta" "^5.1.5"
+    "@turf/rhumb-bearing" "^5.1.5"
+    "@turf/rhumb-destination" "^5.1.5"
+    "@turf/rhumb-distance" "^5.1.5"
+
+"@turf/transform-scale@>=4.0.0":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/transform-scale/-/transform-scale-5.1.5.tgz#70fd3ae01856cf7bae9f15ad561cdfe8f89001b9"
+  integrity sha1-cP064BhWz3uunxWtVhzf6PiQAbk=
+  dependencies:
+    "@turf/bbox" "^5.1.5"
+    "@turf/center" "^5.1.5"
+    "@turf/centroid" "^5.1.5"
+    "@turf/clone" "^5.1.5"
+    "@turf/helpers" "^5.1.5"
+    "@turf/invariant" "^5.1.5"
+    "@turf/meta" "^5.1.5"
+    "@turf/rhumb-bearing" "^5.1.5"
+    "@turf/rhumb-destination" "^5.1.5"
+    "@turf/rhumb-distance" "^5.1.5"
+
+"@turf/transform-translate@>=4.0.0":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@turf/transform-translate/-/transform-translate-5.1.5.tgz#530a257fb1dc7268dadcab34e67901eb2a3dec63"
+  integrity sha1-Uwolf7Hccmja3Ks05nkB6yo97GM=
+  dependencies:
+    "@turf/clone" "^5.1.5"
+    "@turf/helpers" "^5.1.5"
+    "@turf/invariant" "^5.1.5"
+    "@turf/meta" "^5.1.5"
+    "@turf/rhumb-destination" "^5.1.5"
+
+"@turf/union@>=4.0.0":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/@turf/union/-/union-6.0.3.tgz#463b62d71c406f40a6978f560bfb92e88fe7db56"
+  integrity sha512-SJPhEvsR96k4vFqymxPPC43jcqFydTafGjHWnYzlupxqUDzIYD8X5d9Ed8mONl2T9oM4ErbNuuZ9j/eHvoWtKw==
+  dependencies:
+    "@turf/helpers" "6.x"
+    "@turf/invariant" "6.x"
+    martinez-polygon-clipping "^0.4.3"
+
+"@types/geojson@*":
+  version "7946.0.7"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.7.tgz#c8fa532b60a0042219cdf173ca21a975ef0666ad"
+  integrity sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ==
+
+"@types/mapbox-gl@*":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@types/mapbox-gl/-/mapbox-gl-1.11.1.tgz#06cb2f11e4db648ce32d3fd337fef163a2f04b80"
+  integrity sha512-dkcnCkwm3Eb2LioVUTi21LUOyaa97sAQKZ+qn6DCAkP+C2gm514hCLvm3hfHsTWGBaZuFgHoYYZbPQ/LCrwkaw==
+  dependencies:
+    "@types/geojson" "*"
+
+"@types/prop-types@*":
+  version "15.7.3"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
+  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
+"@types/react-map-gl@5.2.2":
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/@types/react-map-gl/-/react-map-gl-5.2.2.tgz#21b61427a70759f68e57fa597532d5c4e0204a6e"
+  integrity sha512-VxPjj2EvmGGjOAXUmFOBRHnvdzhe4FVtic6+tWCfob9w74Vm/ZyVerRXkL03+/I1+Ejk8qhbRDfii3zDzr56Lw==
+  dependencies:
+    "@types/geojson" "*"
+    "@types/mapbox-gl" "*"
+    "@types/react" "*"
+    "@types/viewport-mercator-project" "*"
+
+"@types/react@*":
+  version "16.9.46"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.46.tgz#f0326cd7adceda74148baa9bff6e918632f5069e"
+  integrity sha512-dbHzO3aAq1lB3jRQuNpuZ/mnu+CdD3H0WVaaBQA8LTT3S33xhVBUj232T8M3tAhSWJs/D/UqORYUlJNl/8VQZg==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
+
+"@types/viewport-mercator-project@*":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@types/viewport-mercator-project/-/viewport-mercator-project-6.1.1.tgz#07cd2ae62e0d54a1265274c8b112d376550b031a"
+  integrity sha512-s8pFUBSyFil9lPtBbBUlqK1fEPeVIX2nSndRtYEHLs2E2CWR9heAQlmAHBK9f1vVZ+aF7lAwlLcl26bsulJHig==
+  dependencies:
+    gl-matrix "^3.2.0"
 
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
@@ -2620,6 +2989,11 @@ cssnano-simple@1.0.0:
     cssnano-preset-simple "^1.0.0"
     postcss "^7.0.18"
 
+csstype@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.2.tgz#ee5ff8f208c8cd613b389f7b222c9801ca62b3f7"
+  integrity sha512-ofovWglpqoqbfLNOTBNZLSbMuGrblAf1efvvArGKOZMBrIoJeu5UsAipQolkijtyQx5MtAzT/J9IHj/CEY1mJw==
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -3774,10 +4148,25 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
+geojson-rbush@3.x:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/geojson-rbush/-/geojson-rbush-3.1.2.tgz#577d6ec70ba986d4e60b741f1df5147faeb82c97"
+  integrity sha512-grkfdg3HIeTjwTfiJe5FT8+fGU3fABCc+vRJDBwdQz9kkLF0Sbif2gs2JUzjewwgmnvLGy9fInySDeADoNuk7w==
+  dependencies:
+    "@turf/bbox" "*"
+    "@turf/helpers" "6.x"
+    "@turf/meta" "6.x"
+    rbush "^2.0.0"
+
 geojson-vt@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/geojson-vt/-/geojson-vt-3.2.1.tgz#f8adb614d2c1d3f6ee7c4265cad4bbf3ad60c8b7"
   integrity sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg==
+
+geojson@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/geojson/-/geojson-0.5.0.tgz#3cd6c96399be65b56ee55596116fe9191ce701c0"
+  integrity sha1-PNbJY5m+ZbVu5VWWEW/pGRznAcA=
 
 get-caller-file@^1.0.1:
   version "1.0.3"
@@ -3808,6 +4197,11 @@ gl-matrix@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/gl-matrix/-/gl-matrix-3.0.0.tgz#888301ac7650e148c3865370e13ec66d08a8381f"
   integrity sha512-PD4mVH/C/Zs64kOozeFnKY8ybhgwxXXQYGWdB4h68krAHknWJgk9uKOn6z8YElh5//vs++90pb6csrTIDWnexA==
+
+gl-matrix@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/gl-matrix/-/gl-matrix-3.3.0.tgz#232eef60b1c8b30a28cbbe75b2caf6c48fd6358b"
+  integrity sha512-COb7LDz+SXaHtl/h4LeaFcNdJdAQSDeVqjiIihSXNrkWObZLhDI4hIkZC11Aeqp7bcE72clzB0BnDXr2SmslRA==
 
 glamor@^2.20.0, glamor@^2.20.40:
   version "2.20.40"
@@ -4881,6 +5275,11 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+  integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
+
 lodash.upperfirst@^4.2.0:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
@@ -5026,6 +5425,23 @@ mapbox-gl@^1.0.0:
     supercluster "^6.0.1"
     tinyqueue "^2.0.0"
     vt-pbf "^3.1.1"
+
+martinez-polygon-clipping@*:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/martinez-polygon-clipping/-/martinez-polygon-clipping-0.7.0.tgz#5ae979d4ba32c6425c8cdd422f14d54276350ab7"
+  integrity sha512-EBxKjlUqrVjzT1HRwJARaSwj66JZqEUl+JnqnrzHZLU4hd4XrCQWqShZx40264NR/pm5wIHRlNEaIrev44wvKA==
+  dependencies:
+    robust-predicates "^2.0.4"
+    splaytree "^0.1.4"
+    tinyqueue "^1.2.0"
+
+martinez-polygon-clipping@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/martinez-polygon-clipping/-/martinez-polygon-clipping-0.4.3.tgz#a3971ddf1da147104b5d0fbbf68f728bb62885c1"
+  integrity sha512-3ZNS0ksKhWTLsmCUkNf+/UimndZ5U2cVOS0I+IjiwF+M23E77TmeOZSmbRJbfCoQUog/vcQ42s3DXrhgOhgPqw==
+  dependencies:
+    splaytree "^0.1.4"
+    tinyqueue "^1.2.0"
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -6650,6 +7066,11 @@ quick-lru@^1.0.0:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
   integrity sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=
 
+quickselect@^1.0.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/quickselect/-/quickselect-1.1.1.tgz#852e412ce418f237ad5b660d70cffac647ae94c2"
+  integrity sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ==
+
 quickselect@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/quickselect/-/quickselect-2.0.0.tgz#f19680a486a5eefb581303e023e98faaf25dd018"
@@ -6689,6 +7110,13 @@ raw-body@2.4.0:
     http-errors "1.7.2"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
+
+rbush@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/rbush/-/rbush-2.0.2.tgz#bb6005c2731b7ba1d5a9a035772927d16a614605"
+  integrity sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==
+  dependencies:
+    quickselect "^1.0.1"
 
 rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
   version "1.2.8"
@@ -6753,6 +7181,19 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-map-gl-draw@^0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/react-map-gl-draw/-/react-map-gl-draw-0.19.2.tgz#0c1f0888cedec9850eb1572c89ad4254bdddc898"
+  integrity sha512-8WW+QrhiGAcAV88k/aSOLtahTf0qmY3q4WA2Y8DvCXBKxFkCA0LZ+JBA8Uq1DCdQ0CNBs5vQvoi0rSJhGYKJpA==
+  dependencies:
+    "@math.gl/web-mercator" "^3.1.3"
+    "@nebula.gl/edit-modes" "0.19.2"
+    "@turf/helpers" "^6.1.4"
+    "@types/react-map-gl" "5.2.2"
+    mjolnir.js "^2.4.0"
+    prop-types "^15.7.2"
+    uuid "^3.4.0"
 
 react-map-gl@^5.2.7:
   version "5.2.7"
@@ -7108,6 +7549,11 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
+robust-predicates@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/robust-predicates/-/robust-predicates-2.0.4.tgz#0a2367a93abd99676d075981707f29cfb402248b"
+  integrity sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg==
+
 run-async@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
@@ -7453,6 +7899,11 @@ spdx-license-ids@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz#81c0ce8f21474756148bbb5f3bfc0f36bf15d76e"
   integrity sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==
+
+splaytree@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/splaytree/-/splaytree-0.1.4.tgz#fc35475248edcc29d4938c9b67e43c6b7e55a659"
+  integrity sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ==
 
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
@@ -7819,6 +8270,11 @@ tinycolor2@^1.4.1:
   resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
   integrity sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=
 
+tinyqueue@^1.2.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/tinyqueue/-/tinyqueue-1.2.3.tgz#b6a61de23060584da29f82362e45df1ec7353f3d"
+  integrity sha512-Qz9RgWuO9l8lT+Y9xvbzhPT2efIUIFd69N7eF7tJ9lnQl0iLj1M7peK7IoUGZL9DJHw9XftqLreccfxcQgYLxA==
+
 tinyqueue@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/tinyqueue/-/tinyqueue-2.0.0.tgz#8c40ceddd977bf133ffb35e903e0abe99d9d4e97"
@@ -8132,6 +8588,11 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
+uuid@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
+  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
@@ -8145,7 +8606,7 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
-"viewport-mercator-project@^6.2.3 || ^7.0.1":
+viewport-mercator-project@>=6.0.0, "viewport-mercator-project@^6.2.3 || ^7.0.1":
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/viewport-mercator-project/-/viewport-mercator-project-7.0.1.tgz#9d7248072f2cbb122f93b63d2b346a5763b8d79a"
   integrity sha512-WKTuTL7o6WKdPQ+gmZhlXL7UpSdCdPUjxkDTBd/3AayBdAFSQGHxsqdbmPBvmoGwvo9KWo/30HTkNo/Z7ORJpw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -998,6 +998,14 @@
   resolved "https://registry.yarnpkg.com/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz#497c67a1cef50d1a2459ba60f315e448d2ad87fe"
   integrity sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==
 
+"@math.gl/web-mercator@^3.1.3":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@math.gl/web-mercator/-/web-mercator-3.2.2.tgz#93e66ded7f3004b92bc931da3e32ef244189679b"
+  integrity sha512-uZbLlST7gbfJV227Ev1oShpYQGon9Nk/i0AoM81mVoEYtd+XxKuoDBYaRIdPNVkkALwF9xFG1lwxHqblrs3v5w==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    gl-matrix "^3.0.0"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -3725,12 +3733,12 @@ fs.realpath@^1.0.0:
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
 fsevents@^1.2.7:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.7.tgz#4851b664a3783e52003b3c66eb0eee1074933aa4"
-  integrity sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.9.tgz#3f5ed66583ccd6f400b5a00db6f7e861363e388f"
+  integrity sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==
   dependencies:
-    nan "^2.9.2"
-    node-pre-gyp "^0.10.0"
+    nan "^2.12.1"
+    node-pre-gyp "^0.12.0"
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -5236,10 +5244,10 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mjolnir.js@^2.2.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/mjolnir.js/-/mjolnir.js-2.2.1.tgz#84fc2352ff2ec58b061b0dab1a5ec67f3d2ad966"
-  integrity sha512-bUTP/NbwOfdrN4TKMjUcarfGmWU5yN6aHFR1ek7BNuFOwHk4PslUZjKzdOp1jwx2m0uCoRa5lG+x82l8Vii7Ng==
+mjolnir.js@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/mjolnir.js/-/mjolnir.js-2.4.1.tgz#63cc66b7d1a52490904103cc1becc597be60c6cf"
+  integrity sha512-bpqKc70aNlijeQCapJ8529EmjVj8VSfYdzh1WsbhWp0XEQSm9hAB6X350OyRVDpH5oTdAyX/NeYFqtwyuO4ZKA==
   dependencies:
     "@babel/runtime" "^7.0.0"
     hammerjs "^2.0.8"
@@ -5303,10 +5311,10 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
-nan@^2.9.2:
-  version "2.12.1"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.12.1.tgz#7b1aa193e9aa86057e3c7bbd0ac448e770925552"
-  integrity sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==
+nan@^2.12.1:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
+  integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -5488,10 +5496,10 @@ node-libs-browser@^2.2.1:
     util "^0.11.0"
     vm-browserify "^1.0.1"
 
-node-pre-gyp@^0.10.0:
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
-  integrity sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==
+node-pre-gyp@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz#39ba4bb1439da030295f899e3b520b7785766149"
+  integrity sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==
   dependencies:
     detect-libc "^1.0.2"
     mkdirp "^0.5.1"
@@ -6746,17 +6754,17 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-map-gl@^5.0.11:
-  version "5.0.11"
-  resolved "https://registry.yarnpkg.com/react-map-gl/-/react-map-gl-5.0.11.tgz#4a2f6e6052127a40254e4e1f52ac4a118fc0413f"
-  integrity sha512-CFhGkgHjyeoNz0z0pEmswc4bWlHGpAkBAXAFKSpipQlxgk0URHB3XIjKtWp9XXpKgqsgjmgMtTlnCFrwSS9B1w==
+react-map-gl@^5.2.7:
+  version "5.2.7"
+  resolved "https://registry.yarnpkg.com/react-map-gl/-/react-map-gl-5.2.7.tgz#a3d6eda15ee8abb87b9acd855a0f6996cc364188"
+  integrity sha512-nwn/ThhZzlFB5SHzCbKjW2WKhrH9y3uq92PvTQSTIkaZf3eHgfOM4wsRUXR2UncFY8fAdm1ymdYHUwZUqx/2SQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
     mapbox-gl "^1.0.0"
-    mjolnir.js "^2.2.0"
+    mjolnir.js "^2.4.0"
     prop-types "^15.7.2"
     react-virtualized-auto-sizer "^1.0.2"
-    viewport-mercator-project "^6.1.0"
+    viewport-mercator-project "^6.2.3 || ^7.0.1"
 
 react-scrollbar-size@^2.0.2:
   version "2.1.0"
@@ -8137,13 +8145,12 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
-viewport-mercator-project@^6.1.0:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/viewport-mercator-project/-/viewport-mercator-project-6.1.1.tgz#d7b2cb3cb772b819f1daab17cf4019102a9102a6"
-  integrity sha512-nI0GEmXnESwZxWSJuaQkdCnvOv6yckUfqqFbNB8KWVbQY3eUExVM4ZziqCVVs5mNznLjDF1auj6HLW5D5DKcng==
+"viewport-mercator-project@^6.2.3 || ^7.0.1":
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/viewport-mercator-project/-/viewport-mercator-project-7.0.1.tgz#9d7248072f2cbb122f93b63d2b346a5763b8d79a"
+  integrity sha512-WKTuTL7o6WKdPQ+gmZhlXL7UpSdCdPUjxkDTBd/3AayBdAFSQGHxsqdbmPBvmoGwvo9KWo/30HTkNo/Z7ORJpw==
   dependencies:
-    "@babel/runtime" "^7.0.0"
-    gl-matrix "^3.0.0"
+    "@math.gl/web-mercator" "^3.1.3"
 
 vm-browserify@^1.0.1:
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1282,7 +1282,7 @@
   dependencies:
     "@turf/helpers" "^5.1.5"
 
-"@turf/nearest-point-on-line@>=4.0.0":
+"@turf/nearest-point-on-line@>=4.0.0", "@turf/nearest-point-on-line@^6.0.2":
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/@turf/nearest-point-on-line/-/nearest-point-on-line-6.0.2.tgz#4b2c1177595d9a1743af76905a9013ced03bc0dc"
   integrity sha512-re9tSEwYyG1EMo4ObXXAKYVhkMVANPIIJQ1V/J1lKcNfHVc1pYmd3D5jkTNBh+oriI9VL4PVML3eqYE+Zcg0mg==
@@ -1370,7 +1370,7 @@
     "@turf/helpers" "^5.1.5"
     "@turf/invariant" "^5.1.5"
 
-"@turf/rhumb-distance@6.x":
+"@turf/rhumb-distance@6.x", "@turf/rhumb-distance@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@turf/rhumb-distance/-/rhumb-distance-6.0.1.tgz#ae1c5c823b4b04f75cd7fc240f7f93647db8bdd4"
   integrity sha512-3G45DQtQByzzfHFPcCyJdUZFwsd45zfZ7sAb1ddF7mhEj4G70+T2G3GKjInymqDNrbyh2gbG6wQiZSToC8Uf9g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1197,7 +1197,7 @@
     "@turf/meta" "6.x"
     martinez-polygon-clipping "*"
 
-"@turf/distance@6.x", "@turf/distance@>=4.0.0":
+"@turf/distance@6.x", "@turf/distance@>=4.0.0", "@turf/distance@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@turf/distance/-/distance-6.0.1.tgz#0761f28784286e7865a427c4e7e3593569c2dea8"
   integrity sha512-q7t7rWIWfkg7MP1Vt4uLjSEhe5rPfCO2JjpKmk7JC+QZKEQkuvHEqy3ejW1iC7Kw5ZcZNR3qdMGGz+6HnVwqvg==


### PR DESCRIPTION
# Numérotation métrique
Cette nouvelle fonctionnalité permet d'indiquer si une voie utilise une numérotation métrique. Offrant ainsi la possibilité à l'utilisateur de tracer ses voies sur la carte afin d'obtenir une assistance spécifique pour la numérotation de ce type de voie.

## Tracer la voie
En quelques cliques, l'utilisateur peut utiliser la carte afin de tracer la voie. Le fond de carte passera automatiquement en vu satellite afin de facilité le dessin, notamment dans le cas d'une création de voie. Une fois terminé, le précédent fond de carte utilisé sera chargé.
![trace](https://user-images.githubusercontent.com/7040549/92573120-9d309380-f285-11ea-9df1-bc1ebc15c063.gif)

## Suggestion de numérotation des adresses
Lors de la création des adresses, l'éditeur suggérera à l'utilisateur quel numéro choisir en fonction de sa position sur la voie. L'utilisateur pourra toutefois choisir le numéro qui lui semble juste.

![numerotation](https://user-images.githubusercontent.com/7040549/92573707-758dfb00-f286-11ea-8122-24f3f1cedb73.gif)

⚠️ Cette PR à besoin de https://github.com/etalab/api-bal/pull/220