### PR TITLE
Possibilité de changer une voie sans numéro en toponyme

### DIFF
--- a/components/bal/voie-editor.js
+++ b/components/bal/voie-editor.js
@@ -14,7 +14,7 @@ import useKeyEvent from '../../hooks/key-event'
 import PositionEditor from './position-editor'
 import DrawEditor from './draw-editor'
 
-function VoieEditor({initialValue, onSubmit, onCancel, isEnabledComplement}) {
+function VoieEditor({initialValue, onSubmit, onCancel, hasNumeros, isEnabledComplement}) {
   const position = initialValue ? initialValue.positions[0] : null
 
   const [isLoading, setIsLoading] = useState(false)
@@ -61,6 +61,8 @@ function VoieEditor({initialValue, onSubmit, onCancel, isEnabledComplement}) {
           type: positionType
         }
       ]
+    } else {
+      body.positions = []
     }
 
     try {
@@ -162,7 +164,7 @@ function VoieEditor({initialValue, onSubmit, onCancel, isEnabledComplement}) {
         onChange={onIsMetricChange}
       />
 
-      {!initialValue && (
+      {(isToponyme || !hasNumeros) && (
         <Checkbox
           checked={isToponyme}
           label='Cette voie est un toponyme'
@@ -223,13 +225,15 @@ VoieEditor.propTypes = {
   }),
   onSubmit: PropTypes.func.isRequired,
   onCancel: PropTypes.func,
-  isEnabledComplement: PropTypes.bool
+  isEnabledComplement: PropTypes.bool,
+  hasNumeros: PropTypes.bool
 }
 
 VoieEditor.defaultProps = {
   initialValue: null,
   onCancel: null,
-  isEnabledComplement: false
+  isEnabledComplement: false,
+  hasNumeros: false
 }
 
 export default VoieEditor

--- a/pages/bal/commune.js
+++ b/pages/bal/commune.js
@@ -41,11 +41,6 @@ const Commune = React.memo(({commune, defaultVoies}) => {
     ]
   })
 
-  const numerosList = useCallback(async id => {
-    const numero = await getNumeros(id)
-    setSelectedVoieHasNumeros(numero.length > 0)
-  }, [setSelectedVoieHasNumeros])
-
   const onPopulate = useCallback(async () => {
     setIsPopulating(true)
 
@@ -81,10 +76,12 @@ const Commune = React.memo(({commune, defaultVoies}) => {
   }, [])
 
   const onEnableEditing = useCallback(async idVoie => {
-    await numerosList(idVoie)
+    const numeros = await getNumeros(idVoie)
+
+    setSelectedVoieHasNumeros(numeros.length > 0)
     setIsAdding(false)
     setEditingId(idVoie)
-  }, [setEditingId, numerosList])
+  }, [setEditingId, setSelectedVoieHasNumeros])
 
   const onEdit = useCallback(async ({nom, typeNumerotation, trace, positions, complement}) => {
     await editVoie(editingId, {

--- a/pages/bal/commune.js
+++ b/pages/bal/commune.js
@@ -1,4 +1,4 @@
-import React, {useState, useCallback, useContext} from 'react'
+import React, {useState, useCallback, useContext, useEffect} from 'react'
 import PropTypes from 'prop-types'
 import Router from 'next/router'
 import {sortBy} from 'lodash'
@@ -22,7 +22,7 @@ const Commune = React.memo(({commune, defaultVoies}) => {
   const [isAdding, setIsAdding] = useState(false)
   const [isPopulating, setIsPopulating] = useState(false)
   const [toRemove, setToRemove] = useState(null)
-  const [hasNumeros, setHasNumeros] = useState(false)
+  const [selectedVoieHasNumeros, setSelectedVoieHasNumeros] = useState(false)
 
   const {token} = useContext(TokenContext)
 
@@ -43,8 +43,8 @@ const Commune = React.memo(({commune, defaultVoies}) => {
 
   const numerosList = useCallback(async id => {
     const numero = await getNumeros(id)
-    setHasNumeros(numero.length !== 0)
-  }, [])
+    setSelectedVoieHasNumeros(numero.length > 0)
+  }, [setSelectedVoieHasNumeros])
 
   const onPopulate = useCallback(async () => {
     setIsPopulating(true)
@@ -117,6 +117,12 @@ const Commune = React.memo(({commune, defaultVoies}) => {
     setIsAdding(false)
     setEditingId(null)
   }, [setEditingId])
+
+  useEffect(() => {
+    if (!editingId) {
+      setSelectedVoieHasNumeros(false)
+    }
+  }, [editingId])
 
   return (
     <>
@@ -201,7 +207,7 @@ const Commune = React.memo(({commune, defaultVoies}) => {
               <Table.Row key={voie._id} height='auto'>
                 <Table.Cell display='block' paddingY={12} background='tint1'>
                   <VoieEditor
-                    hasNumeros={hasNumeros}
+                    hasNumeros={selectedVoieHasNumeros}
                     isEnabledComplement={Boolean(baseLocale.enableComplement)}
                     initialValue={voie}
                     onSubmit={onEdit}

--- a/pages/bal/commune.js
+++ b/pages/bal/commune.js
@@ -4,7 +4,7 @@ import Router from 'next/router'
 import {sortBy} from 'lodash'
 import {Pane, Heading, Text, Paragraph, Table, Button} from 'evergreen-ui'
 
-import {getVoies, addVoie, populateCommune, editVoie, removeVoie} from '../../lib/bal-api'
+import {getVoies, addVoie, populateCommune, editVoie, removeVoie, getNumeros} from '../../lib/bal-api'
 
 import TokenContext from '../../contexts/token'
 import BalDataContext from '../../contexts/bal-data'
@@ -22,6 +22,7 @@ const Commune = React.memo(({commune, defaultVoies}) => {
   const [isAdding, setIsAdding] = useState(false)
   const [isPopulating, setIsPopulating] = useState(false)
   const [toRemove, setToRemove] = useState(null)
+  const [hasNumeros, setHasNumeros] = useState(false)
 
   const {token} = useContext(TokenContext)
 
@@ -39,6 +40,11 @@ const Commune = React.memo(({commune, defaultVoies}) => {
       'nom'
     ]
   })
+
+  const numerosList = useCallback(async id => {
+    const numero = await getNumeros(id)
+    setHasNumeros(numero.length !== 0)
+  }, [])
 
   const onPopulate = useCallback(async () => {
     setIsPopulating(true)
@@ -74,10 +80,11 @@ const Commune = React.memo(({commune, defaultVoies}) => {
     setIsAdding(true)
   }, [])
 
-  const onEnableEditing = useCallback(idVoie => {
+  const onEnableEditing = useCallback(async idVoie => {
+    await numerosList(idVoie)
     setIsAdding(false)
     setEditingId(idVoie)
-  }, [setEditingId])
+  }, [setEditingId, numerosList])
 
   const onEdit = useCallback(async ({nom, typeNumerotation, trace, positions, complement}) => {
     await editVoie(editingId, {
@@ -194,6 +201,7 @@ const Commune = React.memo(({commune, defaultVoies}) => {
               <Table.Row key={voie._id} height='auto'>
                 <Table.Cell display='block' paddingY={12} background='tint1'>
                   <VoieEditor
+                    hasNumeros={hasNumeros}
                     isEnabledComplement={Boolean(baseLocale.enableComplement)}
                     initialValue={voie}
                     onSubmit={onEdit}

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -25,7 +25,6 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
   const [isAdding, setIsAdding] = useState(false)
   const [error, setError] = useState()
   const [isRemoveWarningShown, setIsRemoveWarningShown] = useState(false)
-  const [hasNumeros, setHasNumeros] = useState(false)
 
   const {token} = useContext(TokenContext)
 
@@ -115,10 +114,9 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
   }, [setEditingId])
 
   const onEnableVoieEditing = useCallback(() => {
-    setHasNumeros(filtered.length !== 0)
     setEditingId(voie._id)
     setHovered(false)
-  }, [setEditingId, voie._id, filtered])
+  }, [setEditingId, voie._id])
 
   const onEdit = useCallback(async ({numero, voie, suffixe, comment, positions}) => {
     await editNumero(editingId, {
@@ -201,7 +199,7 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
       >
         {editingId === voie._id ? (
           <VoieEditor
-            hasNumeros={hasNumeros}
+            hasNumeros={numeros.length > 0}
             initialValue={{...currentVoie}}
             isEnabledComplement={Boolean(baseLocale.enableComplement)}
             onSubmit={onEditVoie}

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -25,6 +25,7 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
   const [isAdding, setIsAdding] = useState(false)
   const [error, setError] = useState()
   const [isRemoveWarningShown, setIsRemoveWarningShown] = useState(false)
+  const [hasNumeros, setHasNumeros] = useState(false)
 
   const {token} = useContext(TokenContext)
 
@@ -114,9 +115,10 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
   }, [setEditingId])
 
   const onEnableVoieEditing = useCallback(() => {
+    setHasNumeros(filtered.length !== 0)
     setEditingId(voie._id)
     setHovered(false)
-  }, [setEditingId, voie._id])
+  }, [setEditingId, voie._id, filtered])
 
   const onEdit = useCallback(async ({numero, voie, suffixe, comment, positions}) => {
     await editNumero(editingId, {
@@ -199,6 +201,7 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
       >
         {editingId === voie._id ? (
           <VoieEditor
+            hasNumeros={hasNumeros}
             initialValue={{...currentVoie}}
             isEnabledComplement={Boolean(baseLocale.enableComplement)}
             onSubmit={onEditVoie}


### PR DESCRIPTION
## Issue #207 

Lors de l'édition d'une voie sans numéro, il est possible de cocher la case permettant d'indiquer que c'est un toponyme.

capture
![Capture d’écran du 2020-09-29 15-46-38](https://user-images.githubusercontent.com/45098730/94566748-0004c180-026b-11eb-9e0c-8f7b176a02bf.png)
