### PR TITLE
Reformulation du formulaire de création des BAL

### DIFF
--- a/pages/new/create-form.js
+++ b/pages/new/create-form.js
@@ -86,7 +86,6 @@ function CreateForm({defaultCommune}) {
         label='Commune'
         maxWidth={500}
         disabled={isLoading}
-        hint='Vous pourrez ajouter plusieurs communes à la Base Adresse Locale plus tard.'
         onSelect={onSelect}
       />
 

--- a/pages/new/index.js
+++ b/pages/new/index.js
@@ -20,8 +20,8 @@ function Index({defaultCommune, isTest}) {
 
   return (
     <FullscreenContainer
-      title='Nouvelle Base Adresse Locale'
-      subtitle='Sélectionnez une commune pour laquelle vous souhaitez créer ou modifier une Base Adresse Locale.'
+      title={`Nouvelle Base Adresse Locale ${isTest ? 'de démonstration' : ''}`}
+      subtitle={`Sélectionnez une commune pour laquelle vous souhaitez créer ou modifier une Base Adresse Locale ${isTest ? ' de démonstration' : ''}.`}
     >
       <Pane paddingTop={16} flex={1}>
         {isTest ? (

--- a/pages/new/test-form.js
+++ b/pages/new/test-form.js
@@ -52,7 +52,6 @@ function TestForm({defaultCommune}) {
         label='Commune'
         maxWidth={500}
         disabled={isLoading}
-        hint='Vous pourrez ajouter plusieurs communes à la Base Adresse Locale plus tard.'
         onSelect={onSelect}
       />
 

--- a/pages/new/test-form.js
+++ b/pages/new/test-form.js
@@ -63,7 +63,7 @@ function TestForm({defaultCommune}) {
       />
 
       <Button height={40} marginTop={8} type='submit' appearance='primary' intent='success' isLoading={isLoading} iconAfter={isLoading ? null : 'plus'}>
-        {isLoading ? 'En cours de création…' : 'Créer la Base Adresse Locale'}
+        {isLoading ? 'En cours de création…' : 'Créer la Base Adresse Locale de démonstration'}
       </Button>
     </Pane>
   )


### PR DESCRIPTION
- Suppression de l'indice "Vous pourrez ajouter plusieurs communes à la Base Adresse Locale plus tard."
- Ajout du terme "Démonstration" afin de mieux qualifier la création des BAL de tests.