### PR TITLE
Corrige le chargement des sources et des layers empêchant le changement de fond de carte

### DIFF
--- a/components/map/hooks/layers.js
+++ b/components/map/hooks/layers.js
@@ -3,22 +3,30 @@ import {useMemo} from 'react'
 import {getVoiesLabelLayer, getVoieTraceLayer} from '../layers/voies'
 import {getNumerosPointLayer, getNumerosLabelLayer} from '../layers/numeros'
 
-function useLayers(voie, style) {
+function useLayers(voie, sources, style) {
   return useMemo(() => {
-    const layers = [
-      getNumerosPointLayer(style),
-      getNumerosLabelLayer(),
-      getVoieTraceLayer(style)
-    ]
+    const hasNumeros = sources.find(({name}) => name === 'positions')
+    const hasVoies = sources.find(({name}) => name === 'voies')
 
-    if (!voie) {
+    const layers = hasVoies ? [
+      getVoieTraceLayer(style)
+    ] : []
+
+    if (hasNumeros) {
+      layers.push(
+        getNumerosPointLayer(style),
+        getNumerosLabelLayer()
+      )
+    }
+
+    if (!voie && hasVoies) {
       layers.push(
         getVoiesLabelLayer(style)
       )
     }
 
     return layers
-  }, [voie, style])
+  }, [voie, sources, style])
 }
 
 export default useLayers

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -106,7 +106,7 @@ function Map({interactive, style: defaultStyle, commune, voie}) {
 
   const sources = useSources(voie, hovered, editingId)
   const bounds = useBounds(commune, voie)
-  const layers = useLayers(voie, style)
+  const layers = useLayers(voie, sources, style)
 
   const mapRef = useCallback(ref => {
     if (ref) {
@@ -120,17 +120,19 @@ function Map({interactive, style: defaultStyle, commune, voie}) {
     }
 
     const layers = [
-      'numeros-point',
-      'numeros-label',
       'voie-trace-line'
     ]
+
+    if (sources.find(({name}) => name === 'positions')) {
+      layers.push('numeros-point', 'numeros-label')
+    }
 
     if (!voie) {
       layers.push('voie-label')
     }
 
     return layers
-  }, [editingId, voie])
+  }, [editingId, sources, voie])
 
   const onViewportChange = useCallback(viewport => {
     setViewport(viewport)


### PR DESCRIPTION
Quand aucune voie ni numéro n'est affiché sur la carte, le chargement de leurs layer provoqué un "freeze" de la carte, empêchant le changement de fond de carte.
  
Ce correctif permet de ne charger que les sources et layers disponible en fonction des features du geojson chargé dans MapBoxGL.

