### PR TITLE
Migration des Bases Adresses Locales entre les domaines [retry]

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,3 +2,5 @@ BAL_API_URL=https://api-bal.adresse.data.gouv.fr/v1
 GEO_API_URL=https://geo.api.gouv.fr
 ADRESSE_URL=https://adresse.data.gouv.fr
 ADRESSE_BACKEND_URL=https://backend.adresse.data.gouv.fr
+EDITEUR_URL=https://editeur.adresse.data.gouv.fr
+MES_ADRESSES_URL=https://mes-adresses.data.gouv.fr

--- a/components/help/help-tabs/base-locale.js
+++ b/components/help/help-tabs/base-locale.js
@@ -1,10 +1,14 @@
 import React from 'react'
 import {Pane, OrderedList, ListItem, Button, Strong, Paragraph, Tablist, Tab, Icon} from 'evergreen-ui'
+import getConfig from 'next/config'
 
 import Tuto from '../tuto'
 import Unauthorized from '../tuto/unauthorized'
 
 import Problems from './problems'
+
+const {publicRuntimeConfig} = getConfig()
+const EDITEUR_URL = publicRuntimeConfig.EDITEUR_URL || 'https://editeur.adresse.data.gouv.fr'
 
 const BaseLocale = () => {
   return (
@@ -51,6 +55,15 @@ const BaseLocale = () => {
         <Paragraph marginTop='default'>
           Une fois vos réglages terminés, cliquez sur <Button marginX={4} appearance='primary'>Enregistrer les changements</Button>
         </Paragraph>
+      </Tuto>
+
+      <Tuto title='Récupérer vos Bases Adresses Locales'>
+        <Paragraph marginTop='default'>
+          Si toutes vos Bases Adresse Locales n’apparaissent pas dans votre liste, il est possible que leur récupération ait échouée.
+        </Paragraph>
+        <OrderedList margin={8}>
+          <ListItem>Vous pouvez tenter de les récupérer de nous en cliquant <a href={`${EDITEUR_URL}/recovery`}>ici</a>.</ListItem>
+        </OrderedList>
       </Tuto>
 
       <Problems>

--- a/components/retrieve-bal-acccess.js
+++ b/components/retrieve-bal-acccess.js
@@ -1,0 +1,24 @@
+
+import React, {useEffect} from 'react'
+import PropTypes from 'prop-types'
+
+import {getBalAccess} from '../lib/tokens'
+
+const RetrieveBALAccess = ({handleBals}) => {
+  useEffect(() => {
+    const getAccess = async () => {
+      const access = await getBalAccess()
+      handleBals(access)
+    }
+
+    getAccess()
+  }, [handleBals])
+
+  return <div />
+}
+
+RetrieveBALAccess.propTypes = {
+  handleBals: PropTypes.func.isRequired
+}
+
+export default RetrieveBALAccess

--- a/contexts/token.js
+++ b/contexts/token.js
@@ -4,7 +4,7 @@ import Router from 'next/router'
 import getConfig from 'next/config'
 
 import {getBaseLocale} from '../lib/bal-api'
-import {getBalToken, getHasRecovered, setHasRecovered, storeBalAccess} from '../lib/tokens'
+import {getBalToken, getHasRecovered, saveRecoveryLocation, setHasRecovered, storeBalAccess} from '../lib/tokens'
 
 const {publicRuntimeConfig} = getConfig()
 const EDITEUR_URL = publicRuntimeConfig.EDITEUR_URL || 'https://editeur.adresse.data.gouv.fr'
@@ -54,6 +54,7 @@ export function TokenContextProvider({balId, token, ...props}) {
         setState({...state, hasRecovered: true})
       } else {
         setHasRecovered(true)
+        saveRecoveryLocation()
         Router.push(`${EDITEUR_URL}/recovery`)
       }
     }

--- a/contexts/token.js
+++ b/contexts/token.js
@@ -1,15 +1,20 @@
 import React, {useState, useCallback, useEffect} from 'react'
 import PropTypes from 'prop-types'
 import Router from 'next/router'
+import getConfig from 'next/config'
 
 import {getBaseLocale} from '../lib/bal-api'
-import {getBalToken, storeBalAccess} from '../lib/tokens'
+import {getBalToken, getHasRecovered, setHasRecovered, storeBalAccess} from '../lib/tokens'
+
+const {publicRuntimeConfig} = getConfig()
+const EDITEUR_URL = publicRuntimeConfig.EDITEUR_URL || 'https://editeur.adresse.data.gouv.fr'
 
 const TokenContext = React.createContext()
 
 export function TokenContextProvider({balId, token, ...props}) {
   const [state, setState] = useState({
-    token: null
+    token: null,
+    hasRecovered: null
   })
 
   const verify = useCallback(async token => {
@@ -41,6 +46,18 @@ export function TokenContextProvider({balId, token, ...props}) {
       }
     }
   }, [verify, balId, token])
+
+  useEffect(() => {
+    if (state.hasRecovered === null) {
+      const hasRecovered = getHasRecovered()
+      if (hasRecovered) {
+        setState({...state, hasRecovered: true})
+      } else {
+        setHasRecovered(true)
+        Router.push(`${EDITEUR_URL}/recovery`)
+      }
+    }
+  }, [state])
 
   const reloadEmails = useCallback(async () => {
     verify(getBalToken(balId))

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -32,7 +32,7 @@ export function getHasRecovered() {
   return JSON.parse(localStorage.getItem(RECOVERY_KEY) || false)
 }
 
-export function setHasRecovered(hasRecovered) {
+export function storeHasRecovered(hasRecovered) {
   localStorage.setItem(RECOVERY_KEY, hasRecovered)
 }
 

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -1,4 +1,6 @@
 const STORAGE_KEY = 'bal-access'
+const RECOVERY_KEY = 'has-recovered'
+const RECOVERY_LOCATION_KEY = 'recovery-storage'
 
 export function getBalAccess() {
   return JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}')
@@ -27,9 +29,20 @@ export function getBalToken(id) {
 }
 
 export function getHasRecovered() {
-  return JSON.parse(localStorage.getItem('has-recovery') || false)
+  return JSON.parse(localStorage.getItem(RECOVERY_KEY) || false)
 }
 
 export function setHasRecovered(hasRecovered) {
-  localStorage.setItem('has-recovery', hasRecovered)
+  localStorage.setItem(RECOVERY_KEY, hasRecovered)
+}
+
+export function saveRecoveryLocation() {
+  sessionStorage.setItem(RECOVERY_LOCATION_KEY, window.location.pathname)
+}
+
+export function getRecoveryLocation() {
+  const pathname = sessionStorage.getItem(RECOVERY_LOCATION_KEY)
+  sessionStorage.removeItem(RECOVERY_LOCATION_KEY)
+
+  return pathname || '/'
 }

--- a/lib/tokens.js
+++ b/lib/tokens.js
@@ -25,3 +25,11 @@ export function getBalToken(id) {
 
   return data[id]
 }
+
+export function getHasRecovered() {
+  return JSON.parse(localStorage.getItem('has-recovery') || false)
+}
+
+export function setHasRecovered(hasRecovered) {
+  localStorage.setItem('has-recovery', hasRecovered)
+}

--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,8 @@ const withConfig = nextRuntimeDotenv({
     'BAL_API_URL',
     'GEO_API_URL',
     'ADRESSE_URL',
+    'EDITEUR_URL',
+    'MES_ADRESSES_URL',
     'ADRESSE_BACKEND_URL'
   ]
 })

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -88,7 +88,7 @@ function App({error, Component, pageProps, query}) {
         </Dialog>
       </Pane>
 
-      <TokenContextProvider balId={query.balId} token={query.token}>
+      <TokenContextProvider balId={query.balId} _token={query.token}>
         <BalDataContextProvider balId={query.balId} codeCommune={query.codeCommune} idVoie={query.idVoie}>
           <DrawContextProvider>
             <MarkerContextProvider>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,7 +1,9 @@
-import React from 'react'
+import React, {useContext} from 'react'
 import dynamic from 'next/dynamic'
 import Router from 'next/router'
 import {Pane, Button, Spinner, Heading} from 'evergreen-ui'
+
+import TokenContext from '../contexts/token'
 
 import Header from '../components/header'
 import Footer from '../components/footer'
@@ -17,18 +19,29 @@ const UserBasesLocales = dynamic(() => import('../components/user-bases-locales'
 })
 
 function Index() {
+  const {hasRecovered} = useContext(TokenContext)
   return (
     <Pane display='flex' flexDirection='column' height='100%'>
       <Header />
-      <Heading padding={16} size={400} color='snow' display='flex' justifyContent='space-between' alignItems='center' backgroundColor='#0053b3' flexShrink='0'>
-        Mes Bases Adresse Locales
-        <Button iconBefore='plus' onClick={() => Router.push('/new')}>Créer une Base Adresse Locale</Button>
-      </Heading>
-      <Pane height='100%' display='flex' flexDirection='column' justifyContent='center'>
-        <UserBasesLocales />
+      <Pane height='100%' display='flex' flexDirection='column'>
+        {hasRecovered ? (
+          <>
+            <Heading padding={16} size={400} color='snow' display='flex' justifyContent='space-between' alignItems='center' backgroundColor='#0053b3' flexShrink='0'>
+            Mes Bases Adresse Locales
+              <Button iconBefore='plus' onClick={() => Router.push('/new')}>Créer une Base Adresse Locale</Button>
+            </Heading>
+            <Pane height='100%' display='flex' flexDirection='column' justifyContent='center'>
+              <UserBasesLocales />
+            </Pane>
+            <DemoBALAlert />
+            <Footer />
+          </>
+        ) : (
+          <Pane height='100%' display='flex' flexDirection='column' flex={1} alignItems='center' justifyContent='center'>
+            <Spinner />
+          </Pane>
+        )}
       </Pane>
-      <DemoBALAlert />
-      <Footer />
     </Pane>
   )
 }

--- a/pages/recovery.js
+++ b/pages/recovery.js
@@ -1,0 +1,79 @@
+import React, {useEffect, useState} from 'react'
+import PropTypes from 'prop-types'
+import dynamic from 'next/dynamic'
+import {useRouter} from 'next/router'
+import {Pane, Heading, Spinner} from 'evergreen-ui'
+
+import {storeBalAccess} from '../lib/tokens'
+
+import Header from '../components/header'
+
+const MES_ADRESSES = '//localhost:8000'
+
+const RetrieveBALAccessComponent = dynamic(() => import('../components/retrieve-bal-acccess'), {
+  ssr: false
+})
+
+function Index({recoveredBals}) {
+  const router = useRouter()
+  const [bals, setBals] = useState()
+
+  useEffect(() => {
+    if (recoveredBals) {
+      Object.keys(recoveredBals).forEach(id => {
+        storeBalAccess(id, recoveredBals[id])
+      })
+
+      router.push('/')
+    }
+  }, [recoveredBals, router])
+
+  useEffect(() => {
+    if (!recoveredBals && bals) {
+      if (Object.keys(bals).length === 0) {
+        setTimeout(() => {
+          router.push(MES_ADRESSES)
+        }, 3000)
+      } else {
+        const query = Object.entries(bals).map(pair => pair.map(encodeURIComponent).join('=')).join('&')
+        const url = `${MES_ADRESSES}/recovery?${query}`
+
+        router.push(url)
+      }
+    }
+  }, [bals, recoveredBals, router])
+
+  return (
+    <Pane display='flex' flexDirection='column' height='100%'>
+      <Header />
+
+      {!recoveredBals && <RetrieveBALAccessComponent handleBals={setBals} />}
+
+      <Pane height='100%' display='flex' flexDirection='column' flex={1} alignItems='center' justifyContent='center'>
+        <Spinner />
+        <Heading marginTop={16}>{bals && Object.keys(bals).length === 0 ?
+          'Aucune Base Adresse Locale n’a été trouvée' :
+          'Récupération de vos Bases Adresses Locales'}
+        </Heading>
+      </Pane>
+    </Pane>
+  )
+}
+
+Index.defaultProps = {
+  recoveredBals: null
+}
+
+Index.propTypes = {
+  recoveredBals: PropTypes.object
+}
+
+Index.getInitialProps = async ({query}) => {
+  console.log(query)
+  return {
+    recoveredBals: Object.keys(query).length > 0 ? query : null,
+    layout: 'fullscreen'
+  }
+}
+
+export default Index

--- a/pages/recovery.js
+++ b/pages/recovery.js
@@ -3,12 +3,14 @@ import PropTypes from 'prop-types'
 import dynamic from 'next/dynamic'
 import {useRouter} from 'next/router'
 import {Pane, Heading, Spinner} from 'evergreen-ui'
+import getConfig from 'next/config'
 
 import {storeBalAccess} from '../lib/tokens'
 
 import Header from '../components/header'
 
-const MES_ADRESSES = '//localhost:8000'
+const {publicRuntimeConfig} = getConfig()
+const MES_ADRESSES_URL = publicRuntimeConfig.MES_ADRESSES_URL || 'https://mes-adresses.data.gouv.fr'
 
 const RetrieveBALAccessComponent = dynamic(() => import('../components/retrieve-bal-acccess'), {
   ssr: false
@@ -32,11 +34,11 @@ function Index({recoveredBals}) {
     if (!recoveredBals && bals) {
       if (Object.keys(bals).length === 0) {
         setTimeout(() => {
-          router.push(MES_ADRESSES)
+          router.push(MES_ADRESSES_URL)
         }, 3000)
       } else {
         const query = Object.entries(bals).map(pair => pair.map(encodeURIComponent).join('=')).join('&')
-        const url = `${MES_ADRESSES}/recovery?${query}`
+        const url = `${MES_ADRESSES_URL}/recovery?${query}`
 
         router.push(url)
       }
@@ -69,7 +71,6 @@ Index.propTypes = {
 }
 
 Index.getInitialProps = async ({query}) => {
-  console.log(query)
   return {
     recoveredBals: Object.keys(query).length > 0 ? query : null,
     layout: 'fullscreen'

--- a/pages/recovery.js
+++ b/pages/recovery.js
@@ -5,7 +5,7 @@ import {useRouter} from 'next/router'
 import {Pane, Heading, Spinner} from 'evergreen-ui'
 import getConfig from 'next/config'
 
-import {storeBalAccess} from '../lib/tokens'
+import {storeBalAccess, getRecoveryLocation} from '../lib/tokens'
 
 import Header from '../components/header'
 
@@ -26,7 +26,8 @@ function Index({recoveredBals}) {
         storeBalAccess(id, recoveredBals[id])
       })
 
-      router.push('/')
+      const pathname = getRecoveryLocation()
+      router.push(pathname)
     }
   }, [recoveredBals, router])
 


### PR DESCRIPTION
Création de la page /recovery qui permet de migrer les Bases Adresses Locales des utilisateurs du domaine editeur.adresse.data.gouv.fr vers mes-adresses.data.gouv.fr

Reverted PR #234 