### PR TITLE
Lien vers le guide de l'éditeur obsolète

### DIFF
--- a/components/help/index.js
+++ b/components/help/index.js
@@ -47,7 +47,7 @@ const Help = () => {
         <Pane padding={16} background='tint2' elevation={1}>
           <Heading>Vous n’avez pas trouvé la solution à votre problème ?</Heading>
           <Paragraph>
-            <Link href='https://adresse.data.gouv.fr/data/docs/guide-bal-v1.0.pdf'>Télécharger le Guide de la Base Adresse Locale</Link>
+            <Link target='_blank' href='https://adresse.data.gouv.fr/guides'>Consultez les guides de l’adressage</Link>
           </Paragraph>
           <Paragraph>ou</Paragraph>
           <Paragraph>


### PR DESCRIPTION
Depuis le guide interactif, le lien renvoyant vers le guide de l'éditeur est obsolète

- Remplacé par un lien vers la page des guides

![Capture d’écran du 2020-10-29 18-32-41](https://user-images.githubusercontent.com/45098730/97611082-0034e000-1a16-11eb-8b75-d709fb7dcfba.png)
