### PR TITLE
Transformation de BAL de démonstration

### DIFF
--- a/components/layout/sidebar.js
+++ b/components/layout/sidebar.js
@@ -5,7 +5,7 @@ import {Pane, Button, Icon} from 'evergreen-ui'
 import useWindowSize from '../../hooks/window-size'
 import BalDataContext from '../../contexts/bal-data'
 
-function Sidebar({isHidden, size, onToggle, ...props}) {
+function Sidebar({isHidden, size, onToggle, top, ...props}) {
   const {innerWidth} = useWindowSize()
   const {editingId, setEditingId} = useContext(BalDataContext)
 
@@ -23,7 +23,7 @@ function Sidebar({isHidden, size, onToggle, ...props}) {
       maxWidth='100vw'
       left={isHidden ? -size : 0}
       right='auto'
-      top={116}
+      top={top}
       bottom={0}
       zIndex={2}
     >
@@ -66,7 +66,8 @@ Sidebar.propTypes = {
   isHidden: PropTypes.bool,
   children: PropTypes.node.isRequired,
   size: PropTypes.number.isRequired,
-  onToggle: PropTypes.func.isRequired
+  onToggle: PropTypes.func.isRequired,
+  top: PropTypes.number.isRequired
 }
 
 Sidebar.defaultProps = {

--- a/components/map/index.js
+++ b/components/map/index.js
@@ -18,7 +18,7 @@ function MapWrapper({animate, left, top, ...props}) {
       position='fixed'
       display='flex'
       transition={animate ? 'left 0.3s' : null}
-      top={116}
+      top={top}
       right={0}
       bottom={0}
       left={left}

--- a/components/sub-header/demo-warning.js
+++ b/components/sub-header/demo-warning.js
@@ -72,11 +72,11 @@ const DemoWarning = ({baseLocale, token}) => {
       >
         <Icon icon='warning-sign' size={20} marginX='.5em' style={{verticalAlign: 'sub'}} />
         <Text>
-          Vous gérez actuellement une Base Adresse Locale de démonstration. Tous les changements peuvent être perdus.
+          Vous êtes actuellement en mode démonstration
         </Text>
         <Dialog
           isShown={isShown}
-          title='Transformer en Base Adresse Locale'
+          title='Sauvegarder mes modifications'
           cancelLabel='Annuler'
           intent='success'
           isConfirmLoading={isLoading}
@@ -110,10 +110,10 @@ const DemoWarning = ({baseLocale, token}) => {
               placeholder='nom@example.com'
               onChange={onEmailChange}
             />
-            <Button appearance='primary' intent='success' type='submit' >{isLoading ? 'Chargement...' : 'Transformer'}</Button>
+            <Button appearance='primary' intent='success' type='submit' >{isLoading ? 'Chargement...' : 'Sauvegarder'}</Button>
           </form>
         </Dialog>
-        <Button height={24} marginX='.5em' onClick={() => setIsShown(true)}>Transformer en Base Adresse Locale</Button>
+        <Button height={24} marginX='.5em' onClick={() => setIsShown(true)}>Sauvegarder mes modifications</Button>
       </div>
     </Pane>
   )

--- a/components/sub-header/demo-warning.js
+++ b/components/sub-header/demo-warning.js
@@ -13,8 +13,8 @@ const DemoWarning = ({baseLocale, token}) => {
   const {communes} = baseLocale
   const [isShown, setIsShown] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
-  const [defaultCommune, setDefaultCommune] = useState()
-  const [nom, onNomChange] = useInput()
+  const [placeholder, setPlaceholder] = useState('')
+  const [nom, setNom] = useState()
   const [email, onEmailChange] = useInput()
   const focusRef = useFocus()
 
@@ -41,12 +41,15 @@ const DemoWarning = ({baseLocale, token}) => {
   useEffect(() => {
     const fetchCommune = async code => {
       if (communes.length > 0) {
-        setDefaultCommune(await getCommune(code))
+        const commune = await getCommune(code)
+        setPlaceholder(commune.nom)
+        setNom(`Adresses de ${commune.nom}`)
       }
     }
 
     fetchCommune(communes[0])
-  }, [communes])
+    return () => null
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <Pane
@@ -77,6 +80,7 @@ const DemoWarning = ({baseLocale, token}) => {
           isConfirmLoading={isLoading}
           confirmLabel={isLoading ? 'Chargement...' : 'Transformer'}
           hasFooter={false}
+          onCloseComplete={() => setIsShown(false)}
         >
           <form onSubmit={onSubmit}>
 
@@ -89,8 +93,8 @@ const DemoWarning = ({baseLocale, token}) => {
               disabled={isLoading}
               value={nom}
               label='Nom de la Base Adresse Locale'
-              placeholder={defaultCommune ? `Adresses de ${defaultCommune.nom}` : 'Nom'}
-              onChange={onNomChange}
+              placeholder={placeholder}
+              onChange={e => setNom(e.target.value)}
             />
 
             <TextInputField

--- a/components/sub-header/demo-warning.js
+++ b/components/sub-header/demo-warning.js
@@ -109,7 +109,7 @@ const DemoWarning = ({baseLocale, token}) => {
               placeholder='nom@example.com'
               onChange={onEmailChange}
             />
-            <Button appearance='primary' intent='success' type='submit' >{isLoading ? 'Chargement...' : 'Sauvegarder'}</Button>
+            <Button appearance='primary' intent='success' isLoading={isLoading} type='submit' >{'Sauvegarder'}</Button>
           </form>
         </Dialog>
         <Button height={24} marginX='.5em' onClick={() => setIsShown(true)}>Sauvegarder mes modifications</Button>

--- a/components/sub-header/demo-warning.js
+++ b/components/sub-header/demo-warning.js
@@ -56,7 +56,7 @@ const DemoWarning = ({baseLocale, token}) => {
       position='fixed'
       top={116}
       left={0}
-      height={40}
+      height={50}
       width='100%'
       backgroundColor='#F7D154'
       elevation={0}

--- a/components/sub-header/demo-warning.js
+++ b/components/sub-header/demo-warning.js
@@ -20,24 +20,23 @@ const DemoWarning = ({baseLocale, token}) => {
 
   const onSubmit = useCallback(async () => {
     setIsLoading(true)
-    if (nom && email) {
-      const bal = await updateBaseLocale(
-        baseLocale._id,
-        {
-          isTest: false,
-          nom: nom.trim(),
-          emails: [email]
-        },
-        token
-      )
 
-      if (bal) {
-        setIsLoading(false)
-        setIsShown(false)
-      }
+    const bal = await updateBaseLocale(
+      baseLocale._id,
+      {
+        isTest: false,
+        nom: nom.trim(),
+        emails: [email]
+      },
+      token
+    )
 
-      Router.push(`/bal/${bal._id}`)
+    if (bal) {
+      setIsLoading(false)
+      setIsShown(false)
     }
+
+    Router.push(`/bal/${bal._id}`)
   }, [baseLocale, token, email, nom])
 
   useEffect(() => {

--- a/components/sub-header/demo-warning.js
+++ b/components/sub-header/demo-warning.js
@@ -20,22 +20,24 @@ const DemoWarning = ({baseLocale, token}) => {
 
   const onSubmit = useCallback(async () => {
     setIsLoading(true)
-    const bal = await updateBaseLocale(
-      baseLocale._id,
-      {
-        isTest: false,
-        nom: nom.trim(),
-        emails: [email]
-      },
-      token
-    )
+    if (nom && email) {
+      const bal = await updateBaseLocale(
+        baseLocale._id,
+        {
+          isTest: false,
+          nom: nom.trim(),
+          emails: [email]
+        },
+        token
+      )
 
-    if (bal) {
-      setIsLoading(false)
-      setIsShown(false)
+      if (bal) {
+        setIsLoading(false)
+        setIsShown(false)
+      }
+
+      Router.push(`/bal/${bal._id}`)
     }
-
-    Router.push(`/bal/${bal._id}`)
   }, [baseLocale, token, email, nom])
 
   useEffect(() => {

--- a/components/sub-header/demo-warning.js
+++ b/components/sub-header/demo-warning.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import {Pane, Text, Button, Icon} from 'evergreen-ui'
+
+const DemoWarning = () => {
+  return (
+    <Pane
+      position='fixed'
+      top={116}
+      left={0}
+      height={40}
+      width='100%'
+      backgroundColor='#F7D154'
+      elevation={0}
+      zIndex={3}
+      display='flex'
+      flexDirection='column'
+      justifyContent='center'
+    >
+      <div
+        style={{margin: 'auto', textAlign: 'center'}}
+      >
+        <Icon icon='warning-sign' size={20} marginX='.5em' style={{verticalAlign: 'sub'}} />
+        <Text>
+          Vous gérez actuellement une Base Adresse Locale de démonstration. Tous les changements peuvent être perdus.
+        </Text>
+        <Button height={24} marginX='.5em' onClick={() => console.log('plop')}>Transformer en Base Adresse Locale</Button>
+      </div>
+    </Pane>
+  )
+}
+
+export default DemoWarning

--- a/components/sub-header/demo-warning.js
+++ b/components/sub-header/demo-warning.js
@@ -31,11 +31,6 @@ const DemoWarning = ({baseLocale, token}) => {
       token
     )
 
-    if (bal) {
-      setIsLoading(false)
-      setIsShown(false)
-    }
-
     Router.push(`/bal/${bal._id}`)
   }, [baseLocale, token, email, nom])
 

--- a/components/sub-header/demo-warning.js
+++ b/components/sub-header/demo-warning.js
@@ -1,7 +1,53 @@
-import React from 'react'
-import {Pane, Text, Button, Icon} from 'evergreen-ui'
+import React, {useState, useEffect, useCallback} from 'react'
+import PropTypes from 'prop-types'
+import {Pane, Text, Button, Icon, Dialog, TextInputField} from 'evergreen-ui'
 
-const DemoWarning = () => {
+import Router from 'next/router'
+import {useInput} from '../../hooks/input'
+import useFocus from '../../hooks/focus'
+
+import {getCommune} from '../../lib/geo-api'
+import {updateBaseLocale} from '../../lib/bal-api'
+
+const DemoWarning = ({baseLocale, token}) => {
+  const {communes} = baseLocale
+  const [isShown, setIsShown] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [defaultCommune, setDefaultCommune] = useState()
+  const [nom, onNomChange] = useInput()
+  const [email, onEmailChange] = useInput()
+  const focusRef = useFocus()
+
+  const onSubmit = useCallback(async () => {
+    setIsLoading(true)
+    const bal = await updateBaseLocale(
+      baseLocale._id,
+      {
+        isTest: false,
+        nom: nom.trim(),
+        emails: [email]
+      },
+      token
+    )
+
+    if (bal) {
+      setIsLoading(false)
+      setIsShown(false)
+    }
+
+    Router.push(`/bal/${bal._id}`)
+  }, [baseLocale, token, email, nom])
+
+  useEffect(() => {
+    const fetchCommune = async code => {
+      if (communes.length > 0) {
+        setDefaultCommune(await getCommune(code))
+      }
+    }
+
+    fetchCommune(communes[0])
+  }, [communes])
+
   return (
     <Pane
       position='fixed'
@@ -23,10 +69,53 @@ const DemoWarning = () => {
         <Text>
           Vous gérez actuellement une Base Adresse Locale de démonstration. Tous les changements peuvent être perdus.
         </Text>
-        <Button height={24} marginX='.5em' onClick={() => console.log('plop')}>Transformer en Base Adresse Locale</Button>
+        <Dialog
+          isShown={isShown}
+          title='Transformer en Base Adresse Locale'
+          cancelLabel='Annuler'
+          intent='success'
+          isConfirmLoading={isLoading}
+          confirmLabel={isLoading ? 'Chargement...' : 'Transformer'}
+          hasFooter={false}
+        >
+          <form onSubmit={onSubmit}>
+
+            <TextInputField
+              required
+              innerRef={focusRef}
+              autoComplete='new-password' // Hack to bypass chrome autocomplete
+              name='nom'
+              id='nom'
+              disabled={isLoading}
+              value={nom}
+              label='Nom de la Base Adresse Locale'
+              placeholder={defaultCommune ? `Adresses de ${defaultCommune.nom}` : 'Nom'}
+              onChange={onNomChange}
+            />
+
+            <TextInputField
+              required
+              type='email'
+              name='email'
+              id='email'
+              disabled={isLoading}
+              value={email}
+              label='Votre adresse email'
+              placeholder='nom@example.com'
+              onChange={onEmailChange}
+            />
+            <Button appearance='primary' intent='success' type='submit' >{isLoading ? 'Chargement...' : 'Transformer'}</Button>
+          </form>
+        </Dialog>
+        <Button height={24} marginX='.5em' onClick={() => setIsShown(true)}>Transformer en Base Adresse Locale</Button>
       </div>
     </Pane>
   )
+}
+
+DemoWarning.propTypes = {
+  baseLocale: PropTypes.object.isRequired,
+  token: PropTypes.string.isRequired
 }
 
 export default DemoWarning

--- a/components/sub-header/index.js
+++ b/components/sub-header/index.js
@@ -17,6 +17,7 @@ import useWindowSize from '../../hooks/window-size'
 import Breadcrumbs from '../breadcrumbs'
 
 import Publication from './publication'
+import Demowarning from './demo-warning'
 
 const {publicRuntimeConfig} = getConfig()
 const ADRESSE_URL = publicRuntimeConfig.ADRESSE_URL || 'https://adresse.data.gouv.fr'
@@ -53,61 +54,62 @@ const SubHeader = React.memo(({commune, voie, layout, isSidebarHidden, onToggle}
   }
 
   return (
-    <Pane
-      position='fixed'
-      top={76}
-      left={0}
-      height={40}
-      width='100%'
-      background='tint1'
-      elevation={0}
-      zIndex={3}
-      display='flex'
-      padding={8}
-    >
-      {layout !== 'fullscreen' && innerWidth && innerWidth < 800 && (
-        <IconButton
-          height={24}
-          marginRight={8}
-          icon='menu'
-          isActive={!isSidebarHidden}
-          appearance='minimal'
-          onClick={onToggle}
+    <>
+      <Pane
+        position='fixed'
+        top={76}
+        left={0}
+        height={40}
+        width='100%'
+        background='tint1'
+        elevation={0}
+        zIndex={3}
+        display='flex'
+        padding={8}
+      >
+        {layout !== 'fullscreen' && innerWidth && innerWidth < 800 && (
+          <IconButton
+            height={24}
+            marginRight={8}
+            icon='menu'
+            isActive={!isSidebarHidden}
+            appearance='minimal'
+            onClick={onToggle}
+          />
+        )}
+
+        <Breadcrumbs
+          baseLocale={baseLocale}
+          commune={commune}
+          voie={voie}
+          marginLeft={8}
         />
-      )}
 
-      <Breadcrumbs
-        baseLocale={baseLocale}
-        commune={commune}
-        voie={voie}
-        marginLeft={8}
-      />
+        <Pane marginLeft='auto' display='flex'>
 
-      <Pane marginLeft='auto' display='flex'>
-
-        <Button
-          height={24}
-          iconAfter='help'
-          appearance='minimal'
-          marginRight={16}
-          color='dimgrey'
-          onClick={() => setShowHelp(!showHelp)}
-        >
+          <Button
+            height={24}
+            iconAfter='help'
+            appearance='minimal'
+            marginRight={16}
+            color='dimgrey'
+            onClick={() => setShowHelp(!showHelp)}
+          >
           Besoin d’aide
-        </Button>
+          </Button>
 
-        <Popover
-          position={Position.BOTTOM_RIGHT}
-          content={
-            <Menu>
-              <Menu.Group>
-                <NextLink href={csvUrl}>
-                  <Menu.Item icon='download' is='a' href={csvUrl} color='inherit' textDecoration='none'>
+          <Popover
+            position={Position.BOTTOM_RIGHT}
+            content={
+              <Menu>
+                <Menu.Group>
+                  <NextLink href={csvUrl}>
+                    <Menu.Item icon='download' is='a' href={csvUrl} color='inherit' textDecoration='none'>
                     Télécharger au format CSV
-                  </Menu.Item>
-                </NextLink>
-              </Menu.Group>
-              {token && (
+                    </Menu.Item>
+                  </NextLink>
+                </Menu.Group>
+                {token && (
                 <>
                   <Menu.Divider />
                   <Menu.Group>
@@ -116,32 +118,36 @@ const SubHeader = React.memo(({commune, voie, layout, isSidebarHidden, onToggle}
                     </Menu.Item>
                   </Menu.Group>
                 </>
-              )}
-            </Menu>
-          }
-        >
-          <Button
-            height={24}
-            iconAfter='cog'
-            appearance='minimal'
-            marginRight={16}
-            color='dimgrey'
+                )}
+              </Menu>
+            }
           >
+            <Button
+              height={24}
+              iconAfter='cog'
+              appearance='minimal'
+              marginRight={16}
+              color='dimgrey'
+            >
             Paramètres
-          </Button>
-        </Popover>
+            </Button>
+          </Popover>
 
-        {!baseLocale.isTest && (
-          <Publication
-            border
-            token={token}
-            baseLocale={baseLocale}
-            status={baseLocale.published ? 'published' : baseLocale.status}
-            onChangeStatus={handleChangeStatus}
-            onPublish={handlePublication}
-          />)}
+          {!baseLocale.isTest && (
+            <Publication
+              border
+              token={token}
+              baseLocale={baseLocale}
+              status={baseLocale.published ? 'published' : baseLocale.status}
+              onChangeStatus={handleChangeStatus}
+              onPublish={handlePublication}
+            />)}
+        </Pane>
       </Pane>
-    </Pane>
+      {baseLocale.isTest && (
+        <Demowarning />
+      )}
+    </>
   )
 })
 

--- a/components/sub-header/index.js
+++ b/components/sub-header/index.js
@@ -17,7 +17,7 @@ import useWindowSize from '../../hooks/window-size'
 import Breadcrumbs from '../breadcrumbs'
 
 import Publication from './publication'
-import Demowarning from './demo-warning'
+import DemoWarning from './demo-warning'
 
 const {publicRuntimeConfig} = getConfig()
 const ADRESSE_URL = publicRuntimeConfig.ADRESSE_URL || 'https://adresse.data.gouv.fr'
@@ -145,7 +145,7 @@ const SubHeader = React.memo(({commune, voie, layout, isSidebarHidden, onToggle}
         </Pane>
       </Pane>
       {baseLocale.isTest && (
-        <Demowarning />
+        <DemoWarning baseLocale={baseLocale} token={token} />
       )}
     </>
   )

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -57,7 +57,7 @@ function App({error, Component, pageProps, query}) {
 
   const topOffset = useMemo(() => {
     if (pageProps.baseLocale && pageProps.baseLocale.isTest) {
-      return 156
+      return 166
     }
 
     return pageProps.baseLocale ? 116 : 0

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -57,7 +57,7 @@ function App({error, Component, pageProps, query}) {
 
   const topOffset = useMemo(() => {
     if (pageProps.baseLocale && pageProps.baseLocale.isTest) {
-      return 166
+      return 166 // Adding space for demo-warning component
     }
 
     return pageProps.baseLocale ? 116 : 0

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -56,7 +56,11 @@ function App({error, Component, pageProps, query}) {
   }, [layout, isHidden])
 
   const topOffset = useMemo(() => {
-    return pageProps.baseLocale ? 40 : 0
+    if (pageProps.baseLocale && pageProps.baseLocale.isTest) {
+      return 156
+    }
+
+    return pageProps.baseLocale ? 116 : 0
   }, [pageProps.baseLocale])
 
   useEffect(() => {


### PR DESCRIPTION
- Ajout d'un bandeau pour prévenir l'utilisateur qu'il se trouve sur une Base Adresse Locale de démonstration.
- Ajout d'un bouton et d'un formulaire permettant de transformer une Base Adresse Locale de démonstration en Base Adresse Locale publiable.

![image](https://user-images.githubusercontent.com/56537238/99247093-be25df80-2806-11eb-92e2-50618dba8eef.png)

![image](https://user-images.githubusercontent.com/56537238/99247154-d5fd6380-2806-11eb-94b2-48bd2bec09a6.png)
