### PR TITLE
Modification du message sur les Bases Adresses Locales de démonstration

### DIFF
--- a/components/bases-locales-list/base-locale-card.js
+++ b/components/bases-locales-list/base-locale-card.js
@@ -47,7 +47,7 @@ const BaseLocaleCard = ({baseLocale, editable, onSelect, onRemove, initialIsOpen
       padding={12}
       display='grid'
       gridTemplateColumns='repeat(1fr)'
-      background={baseLocale.isTest ? '#E4E7EB' : 'tint1'}
+      background={baseLocale.status === 'demo' ? '#E4E7EB' : 'tint1'}
     >
       <Pane padding='.5em' display='flex' justifyContent='space-between' cursor='pointer' onClick={handleIsOpen}>
         <Pane>
@@ -65,7 +65,7 @@ const BaseLocaleCard = ({baseLocale, editable, onSelect, onRemove, initialIsOpen
           )}
         </Pane>
         <Pane display='flex' flexDirection='row' justifyContent='space-between'>
-          {baseLocale.isTest ? (
+          {baseLocale.status === 'demo' ? (
             <Badge isSolid color='neutral' margin='auto'>TEST</Badge>
           ) : (
             <Badge color={badge.color} margin='auto'>{badge.label}</Badge>
@@ -144,9 +144,8 @@ BaseLocaleCard.propTypes = {
     _updated: PropTypes.string,
     _created: PropTypes.string,
     description: PropTypes.string,
-    isTest: PropTypes.bool,
     status: PropTypes.oneOf([
-      'draft', 'ready-to-publish', 'published'
+      'draft', 'ready-to-publish', 'published', 'demo'
     ])
   }).isRequired,
   initialIsOpen: PropTypes.bool.isRequired,

--- a/components/bases-locales-list/base-locale-card.js
+++ b/components/bases-locales-list/base-locale-card.js
@@ -108,7 +108,7 @@ const BaseLocaleCard = ({baseLocale, editable, onSelect, onRemove, initialIsOpen
 
           {editable ? (
             <Pane borderTop display='flex' justifyContent='space-between' paddingTop='1em' marginTop='1em'>
-              {status === 'draft' ? (
+              {status === 'draft' || status === 'demo' ? (
                 <Button iconAfter='trash' intent='danger' onClick={onRemove}>Supprimer</Button>
               ) : (
                 <Tooltip content='Vous ne pouvez pas supprimer une BAL losrqu‘elle est prête à être publiée'>

--- a/components/demo-bal-alert.js
+++ b/components/demo-bal-alert.js
@@ -9,7 +9,7 @@ const DemoBALAlert = () => {
         <Text>
           Vous voulez simplement essayer l’éditeur sans créer de Base Adresse Locale ?
         </Text>
-        <Button appearance='primary' marginLeft='1em' onClick={() => Router.push('/new?test=1')}>Cliquez ici</Button>
+        <Button appearance='primary' marginLeft='1em' onClick={() => Router.push('/new?demo=1')}>Cliquez ici</Button>
       </Alert>
     </Pane>
   )

--- a/components/settings.js
+++ b/components/settings.js
@@ -141,7 +141,7 @@ const Settings = React.memo(({nomBaseLocale, isEnabledComplement}) => {
               id='nom'
               value={nomInput}
               maxWidth={600}
-              disabled={isLoading || baseLocale.isTest}
+              disabled={isLoading || baseLocale.status === 'demo'}
               label='Nom'
               placeholder='Nom'
               onChange={onNomInputChange}
@@ -185,7 +185,7 @@ const Settings = React.memo(({nomBaseLocale, isEnabledComplement}) => {
                 maxWidth={400}
                 isInvalid={Boolean(error && error.includes('mail'))}
                 value={email}
-                disabled={baseLocale.isTest}
+                disabled={baseLocale.status === 'demo'}
                 onChange={onEmailChange}
               />
               {email && !balEmails.includes(email) && (
@@ -224,7 +224,7 @@ const Settings = React.memo(({nomBaseLocale, isEnabledComplement}) => {
             <Switch
               height={20}
               marginBottom={10}
-              disabled={baseLocale.isTest}
+              disabled={baseLocale.status === 'demo'}
               checked={enableComplement}
               onChange={onEnableComplement}
             />
@@ -244,7 +244,7 @@ const Settings = React.memo(({nomBaseLocale, isEnabledComplement}) => {
         )}
       </Pane>
 
-      {baseLocale.isTest && (
+      {baseLocale.status === 'demo' && (
         <Pane padding={16}>
           <Alert
             intent='none'

--- a/components/sub-header/demo-warning.js
+++ b/components/sub-header/demo-warning.js
@@ -7,7 +7,7 @@ import {useInput} from '../../hooks/input'
 import useFocus from '../../hooks/focus'
 
 import {getCommune} from '../../lib/geo-api'
-import {updateBaseLocaleTest} from '../../lib/bal-api'
+import {transformToDraft} from '../../lib/bal-api'
 
 const DemoWarning = ({baseLocale, token}) => {
   const {communes} = baseLocale
@@ -21,7 +21,7 @@ const DemoWarning = ({baseLocale, token}) => {
   const onSubmit = useCallback(async () => {
     setIsLoading(true)
 
-    const bal = await updateBaseLocaleTest(
+    const bal = await transformToDraft(
       baseLocale._id,
       {
         nom: nom ? nom.trim() : null,

--- a/components/sub-header/demo-warning.js
+++ b/components/sub-header/demo-warning.js
@@ -104,7 +104,7 @@ const DemoWarning = ({baseLocale, token}) => {
               placeholder='nom@example.com'
               onChange={onEmailChange}
             />
-            <Button appearance='primary' intent='success' isLoading={isLoading} type='submit' >{'Sauvegarder'}</Button>
+            <Button appearance='primary' intent='success' isLoading={isLoading} type='submit' >Sauvegarder</Button>
           </form>
         </Dialog>
         <Button height={24} marginX='.5em' onClick={() => setIsShown(true)}>Je souhaite la conserver</Button>

--- a/components/sub-header/demo-warning.js
+++ b/components/sub-header/demo-warning.js
@@ -74,11 +74,11 @@ const DemoWarning = ({baseLocale, token}) => {
           cancelLabel='Annuler'
           intent='success'
           isConfirmLoading={isLoading}
-          confirmLabel={isLoading ? 'Chargement...' : 'Conserver'}
+          confirmLabel='Conserver'
           hasFooter={false}
           onCloseComplete={() => setIsShown(false)}
         >
-          <form onSubmit={(onSubmit)}>
+          <form onSubmit={onSubmit}>
 
             <TextInputField
               required
@@ -104,7 +104,7 @@ const DemoWarning = ({baseLocale, token}) => {
               placeholder='nom@example.com'
               onChange={onEmailChange}
             />
-            <Button appearance='primary' intent='success' isLoading={isLoading} type='submit' >{'Conserver'}</Button>
+            <Button appearance='primary' intent='success' isLoading={isLoading} type='submit' >{'Sauvegarder'}</Button>
           </form>
         </Dialog>
         <Button height={24} marginX='.5em' onClick={() => setIsShown(true)}>Je souhaite la conserver</Button>

--- a/components/sub-header/demo-warning.js
+++ b/components/sub-header/demo-warning.js
@@ -18,14 +18,15 @@ const DemoWarning = ({baseLocale, token}) => {
   const [email, onEmailChange] = useInput()
   const focusRef = useFocus()
 
-  const onSubmit = useCallback(async () => {
+  const onSubmit = useCallback(async e => {
+    e.preventDefault()
     setIsLoading(true)
 
     const bal = await transformToDraft(
       baseLocale._id,
       {
         nom: nom ? nom.trim() : null,
-        emails: [email]
+        email
       },
       token
     )
@@ -77,7 +78,7 @@ const DemoWarning = ({baseLocale, token}) => {
           hasFooter={false}
           onCloseComplete={() => setIsShown(false)}
         >
-          <form onSubmit={onSubmit}>
+          <form onSubmit={(onSubmit)}>
 
             <TextInputField
               required

--- a/components/sub-header/demo-warning.js
+++ b/components/sub-header/demo-warning.js
@@ -65,7 +65,7 @@ const DemoWarning = ({baseLocale, token}) => {
       >
         <Icon icon='warning-sign' size={20} marginX='.5em' style={{verticalAlign: 'sub'}} />
         <Text>
-          Vous êtes actuellement en mode démonstration
+          Cette Base Adresse Locale de démonstration sera supprimée d’ici 24 heures sans modifications
         </Text>
         <Dialog
           isShown={isShown}
@@ -73,7 +73,7 @@ const DemoWarning = ({baseLocale, token}) => {
           cancelLabel='Annuler'
           intent='success'
           isConfirmLoading={isLoading}
-          confirmLabel={isLoading ? 'Chargement...' : 'Transformer'}
+          confirmLabel={isLoading ? 'Chargement...' : 'Conserver'}
           hasFooter={false}
           onCloseComplete={() => setIsShown(false)}
         >
@@ -103,10 +103,10 @@ const DemoWarning = ({baseLocale, token}) => {
               placeholder='nom@example.com'
               onChange={onEmailChange}
             />
-            <Button appearance='primary' intent='success' isLoading={isLoading} type='submit' >{'Sauvegarder'}</Button>
+            <Button appearance='primary' intent='success' isLoading={isLoading} type='submit' >{'Conserver'}</Button>
           </form>
         </Dialog>
-        <Button height={24} marginX='.5em' onClick={() => setIsShown(true)}>Sauvegarder mes modifications</Button>
+        <Button height={24} marginX='.5em' onClick={() => setIsShown(true)}>Je souhaite la conserver</Button>
       </div>
     </Pane>
   )

--- a/components/sub-header/index.js
+++ b/components/sub-header/index.js
@@ -131,7 +131,7 @@ const SubHeader = React.memo(({commune, voie, layout, isSidebarHidden, onToggle}
             </Button>
           </Popover>
 
-          {!baseLocale.isTest && (
+          {!baseLocale.status === 'demo' && (
             <Publication
               border
               token={token}
@@ -142,7 +142,7 @@ const SubHeader = React.memo(({commune, voie, layout, isSidebarHidden, onToggle}
             />)}
         </Pane>
       </Pane>
-      {baseLocale.isTest && (
+      {baseLocale.status === 'demo' && (
         <DemoWarning baseLocale={baseLocale} token={token} />
       )}
     </>

--- a/lib/bal-api/index.js
+++ b/lib/bal-api/index.js
@@ -68,12 +68,13 @@ export function createBaseLocale(body) {
   })
 }
 
-export function createBaseLocaleTest() {
-  return request('/bases-locales/test', {
+export function createBaseLocaleDemo(body) {
+  return request('/bases-locales/demo', {
     method: 'POST',
     headers: {
       'content-type': 'application/json'
-    }
+    },
+    body: JSON.stringify(body)
   })
 }
 

--- a/lib/bal-api/index.js
+++ b/lib/bal-api/index.js
@@ -69,7 +69,7 @@ export function createBaseLocale(body) {
 }
 
 export function createBaseLocaleDemo(body) {
-  return request('/bases-locales/demo', {
+  return request('/bases-locales/create-demo', {
     method: 'POST',
     headers: {
       'content-type': 'application/json'
@@ -96,7 +96,7 @@ export async function updateBaseLocale(balId, body, token) {
 
 export async function transformToDraft(balId, body, token) {
   const baseLocale = await request(`/bases-locales/${balId}/transform-to-draft`, {
-    method: 'PUT',
+    method: 'POST',
     headers: {
       authorization: `Token ${token}`,
       'content-type': 'application/json'

--- a/lib/bal-api/index.js
+++ b/lib/bal-api/index.js
@@ -94,8 +94,8 @@ export async function updateBaseLocale(balId, body, token) {
   return baseLocale
 }
 
-export async function updateBaseLocaleTest(balId, body, token) {
-  const baseLocale = await request(`/bases-locales/test/${balId}`, {
+export async function transformToDraft(balId, body, token) {
+  const baseLocale = await request(`/bases-locales/${balId}/transform-to-draft`, {
     method: 'PUT',
     headers: {
       authorization: `Token ${token}`,

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -56,7 +56,7 @@ function App({error, Component, pageProps, query}) {
   }, [layout, isHidden])
 
   const topOffset = useMemo(() => {
-    if (pageProps.baseLocale && pageProps.baseLocale.isTest) {
+    if (pageProps.baseLocale && pageProps.baseLocale.status === 'demo') {
       return 166 // Adding space for demo-warning component
     }
 

--- a/pages/new/demo-form.js
+++ b/pages/new/demo-form.js
@@ -4,14 +4,14 @@ import Router from 'next/router'
 import {Pane, Checkbox, Button, Alert} from 'evergreen-ui'
 
 import {storeBalAccess} from '../../lib/tokens'
-import {addCommune, populateCommune, createBaseLocaleDemo} from '../../lib/bal-api'
+import {createBaseLocaleDemo} from '../../lib/bal-api'
 
 import useFocus from '../../hooks/focus'
 import {useCheckboxInput} from '../../hooks/input'
 
 import {CommuneSearchField} from '../../components/commune-search'
 
-function TestForm({defaultCommune}) {
+function DemoForm({defaultCommune}) {
   const [isLoading, setIsLoading] = useState(false)
 
   const [populate, onPopulateChange] = useCheckboxInput(true)
@@ -71,12 +71,12 @@ function TestForm({defaultCommune}) {
   )
 }
 
-TestForm.propTypes = {
+DemoForm.propTypes = {
   defaultCommune: PropTypes.object
 }
 
-TestForm.defaultProps = {
+DemoForm.defaultProps = {
   defaultCommune: null
 }
 
-export default TestForm
+export default DemoForm

--- a/pages/new/index.js
+++ b/pages/new/index.js
@@ -16,21 +16,21 @@ const BackToUserBals = dynamic(import('./back-to-user-bals'), {
   ssr: false
 })
 
-function Index({defaultCommune, isTest}) {
+function Index({defaultCommune, isDemo}) {
   const [index, setIndex] = useState(0)
 
   return (
     <Pane height='100%' display='flex' flexDirection='column'>
       <Header />
       <Pane padding={12}>
-        <Heading size={600} marginBottom={8}>{`Nouvelle Base Adresse Locale ${isTest ? 'de démonstration' : ''}`}</Heading>
+        <Heading size={600} marginBottom={8}>{`Nouvelle Base Adresse Locale ${isDemo ? 'de démonstration' : ''}`}</Heading>
         <Paragraph>
-          {`Sélectionnez une commune pour laquelle vous souhaitez créer ou modifier une Base Adresse Locale ${isTest ? ' de démonstration' : ''}.`}
+          {`Sélectionnez une commune pour laquelle vous souhaitez créer ou modifier une Base Adresse Locale ${isDemo ? ' de démonstration' : ''}.`}
         </Paragraph>
       </Pane>
 
       <Pane paddingTop={16} flex={1}>
-        {isTest ? (
+        {isDemo ? (
           <TestForm defaultCommune={defaultCommune} />
         ) :
           (<>
@@ -44,14 +44,14 @@ function Index({defaultCommune, isTest}) {
 
             <Pane flex={1} overflowY='scroll'>
               {index === 0 ? (
-                <CreateForm defaultCommune={defaultCommune} isTest={isTest} />
+                <CreateForm defaultCommune={defaultCommune} />
               ) : (
                 <UploadForm />
               )}
             </Pane>
           </>)}
 
-        {!isTest && (
+        {!isDemo && (
           <DemoBALAlert />
         )}
         <Pane display='flex' justifyContent='space-between' alignItems='center' flex={1} margin={16} marginTop={32}>
@@ -73,19 +73,19 @@ Index.getInitialProps = async ({query}) => {
 
   return {
     defaultCommune,
-    isTest: query.test === '1',
+    isDemo: query.demo === '1',
     layout: 'fullscreen'
   }
 }
 
 Index.propTypes = {
   defaultCommune: PropTypes.string,
-  isTest: PropTypes.bool
+  isDemo: PropTypes.bool
 }
 
 Index.defaultProps = {
   defaultCommune: null,
-  isTest: false
+  isDemo: false
 }
 
 export default Index

--- a/pages/new/index.js
+++ b/pages/new/index.js
@@ -10,7 +10,7 @@ import DemoBALAlert from '../../components/demo-bal-alert'
 import Footer from '../../components/footer'
 import CreateForm from './create-form'
 import UploadForm from './upload-form'
-import TestForm from './test-form'
+import DemoForm from './demo-form'
 
 const BackToUserBals = dynamic(import('./back-to-user-bals'), {
   ssr: false
@@ -31,7 +31,7 @@ function Index({defaultCommune, isDemo}) {
 
       <Pane paddingTop={16} flex={1}>
         {isDemo ? (
-          <TestForm defaultCommune={defaultCommune} />
+          <DemoForm defaultCommune={defaultCommune} />
         ) :
           (<>
             <TabNavigation display='flex' marginLeft={16}>

--- a/pages/new/test-form.js
+++ b/pages/new/test-form.js
@@ -4,7 +4,7 @@ import Router from 'next/router'
 import {Pane, Checkbox, Button, Alert} from 'evergreen-ui'
 
 import {storeBalAccess} from '../../lib/tokens'
-import {createBaseLocaleTest, addCommune, populateCommune} from '../../lib/bal-api'
+import {addCommune, populateCommune, createBaseLocaleDemo} from '../../lib/bal-api'
 
 import useFocus from '../../hooks/focus'
 import {useCheckboxInput} from '../../hooks/input'
@@ -26,7 +26,7 @@ function TestForm({defaultCommune}) {
 
     setIsLoading(true)
 
-    const bal = await createBaseLocaleTest()
+    const bal = await createBaseLocaleDemo({commune, populate})
 
     storeBalAccess(bal._id, bal.token)
 

--- a/pages/new/test-form.js
+++ b/pages/new/test-form.js
@@ -30,12 +30,6 @@ function TestForm({defaultCommune}) {
 
     storeBalAccess(bal._id, bal.token)
 
-    await addCommune(bal._id, commune, bal.token)
-
-    if (populate) {
-      await populateCommune(bal._id, commune, bal.token)
-    }
-
     Router.push(
       `/bal/commune?balId=${bal._id}&codeCommune=${commune}`,
       `/bal/${bal._id}/communes/${commune}`


### PR DESCRIPTION
- Modification du message dans le bandeau : 

![Screenshot_2020-11-23 Screenshot](https://user-images.githubusercontent.com/56537238/99981730-0c5c5500-2daa-11eb-85bd-dbd84e82f5f8.png)

- Modification du message dans la boite de dialogue : 

![Screenshot_2020-11-23 Screenshot(1)](https://user-images.githubusercontent.com/56537238/99981738-0ebeaf00-2daa-11eb-9030-ff9b235b4729.png)

- Modification de la fonction `createBaseLocaleDemo`
- Changement de nom pour `updateBaselocaleTest` -> `transformToDraft`
- Suppression des `isTest` et remplacement par `Demo`