### PR TITLE
Gestion native des variables d'environnement par Next.js

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,6 @@
-BAL_API_URL=https://api-bal.adresse.data.gouv.fr/v1
-GEO_API_URL=https://geo.api.gouv.fr
-ADRESSE_URL=https://adresse.data.gouv.fr
-ADRESSE_BACKEND_URL=https://backend.adresse.data.gouv.fr
-EDITEUR_URL=https://editeur.adresse.data.gouv.fr
-MES_ADRESSES_URL=https://mes-adresses.data.gouv.fr
+NEXT_PUBLIC_BAL_API_URL=https://api-bal.adresse.data.gouv.fr/v1
+NEXT_PUBLIC_GEO_API_URL=https://geo.api.gouv.fr
+NEXT_PUBLIC_ADRESSE_URL=https://adresse.data.gouv.fr
+NEXT_PUBLIC_ADRESSE_BACKEND_URL=https://backend.adresse.data.gouv.fr
+NEXT_PUBLIC_EDITEUR_URL=https://editeur.adresse.data.gouv.fr
+NEXT_PUBLIC_MES_ADRESSES_URL=https://mes-adresses.data.gouv.fr

--- a/components/help/help-tabs/base-locale.js
+++ b/components/help/help-tabs/base-locale.js
@@ -1,14 +1,12 @@
 import React from 'react'
 import {Pane, OrderedList, ListItem, Button, Strong, Paragraph, Tablist, Tab, Icon} from 'evergreen-ui'
-import getConfig from 'next/config'
 
 import Tuto from '../tuto'
 import Unauthorized from '../tuto/unauthorized'
 
 import Problems from './problems'
 
-const {publicRuntimeConfig} = getConfig()
-const EDITEUR_URL = publicRuntimeConfig.EDITEUR_URL || 'https://editeur.adresse.data.gouv.fr'
+const EDITEUR_URL = process.env.NEXT_PUBLIC_EDITEUR_URL || 'https://editeur.adresse.data.gouv.fr'
 
 const BaseLocale = () => {
   return (

--- a/components/sub-header/index.js
+++ b/components/sub-header/index.js
@@ -1,7 +1,6 @@
 import React, {useContext} from 'react'
 import PropTypes from 'prop-types'
 import NextLink from 'next/link'
-import getConfig from 'next/config'
 import {Pane, Popover, Menu, IconButton, Position, Button} from 'evergreen-ui'
 
 import {getBaseLocaleCsvUrl, updateBaseLocale} from '../../lib/bal-api'
@@ -19,8 +18,7 @@ import Breadcrumbs from '../breadcrumbs'
 import Publication from './publication'
 import DemoWarning from './demo-warning'
 
-const {publicRuntimeConfig} = getConfig()
-const ADRESSE_URL = publicRuntimeConfig.ADRESSE_URL || 'https://adresse.data.gouv.fr'
+const ADRESSE_URL = process.env.NEXT_PUBLIC_ADRESSE_URL || 'https://adresse.data.gouv.fr'
 
 const SubHeader = React.memo(({commune, voie, layout, isSidebarHidden, onToggle}) => {
   const {baseLocale, reloadBaseLocale} = useContext(BalDataContext)

--- a/contexts/token.js
+++ b/contexts/token.js
@@ -1,13 +1,11 @@
 import React, {useState, useCallback, useEffect} from 'react'
 import PropTypes from 'prop-types'
 import Router from 'next/router'
-import getConfig from 'next/config'
 
 import {getBaseLocale} from '../lib/bal-api'
 import {getBalToken, getHasRecovered, saveRecoveryLocation, storeHasRecovered, storeBalAccess} from '../lib/tokens'
 
-const {publicRuntimeConfig} = getConfig()
-const EDITEUR_URL = publicRuntimeConfig.EDITEUR_URL || 'https://editeur.adresse.data.gouv.fr'
+const EDITEUR_URL = process.env.NEXT_PUBLIC_EDITEUR_URL || 'https://editeur.adresse.data.gouv.fr'
 
 const TokenContext = React.createContext()
 

--- a/lib/adresse-backend/index.js
+++ b/lib/adresse-backend/index.js
@@ -1,8 +1,6 @@
 import fetch from 'isomorphic-unfetch'
-import getConfig from 'next/config'
 
-const {publicRuntimeConfig} = getConfig()
-const ADRESSE_BACKEND_URL = publicRuntimeConfig.ADRESSE_BACKEND_URL || 'https://backend.adresse.data.gouv.fr'
+const ADRESSE_BACKEND_URL = process.env.NEXT_PUBLIC_ADRESSE_BACKEND_URL || 'https://backend.adresse.data.gouv.fr'
 
 async function request(url, opts = {}) {
   const {json, ...options} = opts

--- a/lib/bal-api/index.js
+++ b/lib/bal-api/index.js
@@ -1,9 +1,7 @@
 import fetch from 'isomorphic-unfetch'
-import getConfig from 'next/config'
 import {getPublishedBasesLocales} from '../adresse-backend'
 
-const {publicRuntimeConfig} = getConfig()
-const BAL_API_URL = publicRuntimeConfig.BAL_API_URL || 'https://api-bal.adresse.data.gouv.fr/v1'
+const BAL_API_URL = process.env.NEXT_PUBLIC_BAL_API_URL || 'https://api-bal.adresse.data.gouv.fr/v1'
 
 async function request(url, opts = {}) {
   const {json, ...options} = opts

--- a/lib/geo-api/index.js
+++ b/lib/geo-api/index.js
@@ -1,9 +1,7 @@
 import qs from 'querystring'
 import fetch from 'isomorphic-unfetch'
-import getConfig from 'next/config'
 
-const {publicRuntimeConfig} = getConfig()
-const GEO_API_URL = publicRuntimeConfig.GEO_API_URL || 'https://geo.api.gouv.fr'
+const GEO_API_URL = process.env.NEXT_PUBLIC_GEO_API_URL || 'https://geo.api.gouv.fr'
 
 async function request(url, options) {
   const res = await fetch(`${GEO_API_URL}${url}`, options)

--- a/next.config.js
+++ b/next.config.js
@@ -1,28 +1,14 @@
-const nextRuntimeDotenv = require('next-runtime-dotenv')
 const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true'
 })
 
-const withConfig = nextRuntimeDotenv({
-  public: [
-    'BAL_API_URL',
-    'GEO_API_URL',
-    'ADRESSE_URL',
-    'EDITEUR_URL',
-    'MES_ADRESSES_URL',
-    'ADRESSE_BACKEND_URL'
-  ]
-})
-
-module.exports = withBundleAnalyzer(
-  withConfig({
-    webpack(config) {
-      config.node = {
-        ...config.node,
-        fs: 'empty'
-      }
-
-      return config
+module.exports = withBundleAnalyzer({
+  webpack(config) {
+    config.node = {
+      ...config.node,
+      fs: 'empty'
     }
-  })
-)
+
+    return config
+  }
+})

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "isomorphic-unfetch": "^3.1.0",
     "lodash": "^4.17.20",
     "next": "^10.0.2",
-    "next-runtime-dotenv": "^1.3.0",
     "prop-types": "^15.7.2",
     "randomcolor": "^0.6.2",
     "react": "^17.0.1",

--- a/pages/recovery.js
+++ b/pages/recovery.js
@@ -2,14 +2,12 @@ import React, {useEffect, useState} from 'react'
 import PropTypes from 'prop-types'
 import dynamic from 'next/dynamic'
 import {Pane, Heading, Spinner} from 'evergreen-ui'
-import getConfig from 'next/config'
 
 import {storeBalAccess, getRecoveryLocation} from '../lib/tokens'
 
 import Header from '../components/header'
 
-const {publicRuntimeConfig} = getConfig()
-const MES_ADRESSES_URL = publicRuntimeConfig.MES_ADRESSES_URL || 'https://mes-adresses.data.gouv.fr'
+const MES_ADRESSES_URL = process.env.NEXT_PUBLIC_MES_ADRESSES_URL || 'https://mes-adresses.data.gouv.fr'
 
 const RetrieveBALAccessComponent = dynamic(() => import('../components/retrieve-bal-acccess'), {
   ssr: false

--- a/yarn.lock
+++ b/yarn.lock
@@ -2694,11 +2694,6 @@ dot-prop@^4.1.0:
   dependencies:
     is-obj "^1.0.0"
 
-dotenv@^8.0.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.1.0.tgz#d811e178652bfb8a1e593c6dd704ec7e90d85ea2"
-  integrity sha512-GUE3gqcDCaMltj2++g6bRQ5rBJWtkWTmqmD0fo1RnnMuUqHNCt2oTPeDnS9n6fKYvlhn7AeBkb38lymBtWBQdA==
-
 downshift@^3.3.1:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/downshift/-/downshift-3.3.4.tgz#959be157e48be2ec2bbc50f184303647fc719026"
@@ -5397,13 +5392,6 @@ neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
-
-next-runtime-dotenv@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/next-runtime-dotenv/-/next-runtime-dotenv-1.3.0.tgz#8ec93bb55b42125ec11d923d4dc6c7cd72bea220"
-  integrity sha512-evk1JQlryyJ/LOhoGNrDXk2bPWh6ayIBt8/jLKhrRaDSSXSXPHSjU+yejmzS7qG459dWYjlRfbiXin+Opul3qQ==
-  dependencies:
-    dotenv "^8.0.0"
 
 next-tick@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
L'ancienne méthode utilisant `next-runtime-dotenv` est obsolète depuis Next.js 9.4.

Nouvelle documentation : https://nextjs.org/docs/basic-features/environment-variables