### PR TITLE
Tri de la liste des Bases Adresse Locales par date de mise à jour ou par nom

### DIFF
--- a/components/bases-locales-list/index.js
+++ b/components/bases-locales-list/index.js
@@ -2,6 +2,7 @@ import React, {useState, useCallback} from 'react'
 import PropTypes from 'prop-types'
 import Router from 'next/router'
 import {Pane, Table, Paragraph} from 'evergreen-ui'
+import {orderBy} from 'lodash'
 
 import {getBalAccess, getBalToken, removeBalAccess} from '../../lib/tokens'
 
@@ -13,7 +14,7 @@ import {listBasesLocales, removeBaseLocale} from '../../lib/bal-api'
 import DeleteWarning from '../delete-warning'
 import BaseLocaleCard from './base-locale-card'
 
-function BasesLocalesList({basesLocales, updateBasesLocales}) {
+function BasesLocalesList({basesLocales, updateBasesLocales, all}) {
   const [toRemove, setToRemove] = useState(null)
 
   const [setError] = useError(null)
@@ -93,7 +94,7 @@ function BasesLocalesList({basesLocales, updateBasesLocales}) {
               </Table.Row>
             )}
             <Table.Body background='tint1'>
-              {filtered.map(bal => (
+              {orderBy(filtered, [all ? filter => filter.nom.toLowerCase() : '_updated'], [all ? 'asc' : 'desc']).map(bal => (
                 <BaseLocaleCard
                   key={bal._id}
                   baseLocale={bal}
@@ -121,12 +122,14 @@ BasesLocalesList.getInitialProps = async () => {
 }
 
 BasesLocalesList.defaultProps = {
-  updateBasesLocales: null
+  updateBasesLocales: null,
+  all: false
 }
 
 BasesLocalesList.propTypes = {
   basesLocales: PropTypes.array.isRequired,
-  updateBasesLocales: PropTypes.func
+  updateBasesLocales: PropTypes.func,
+  all: PropTypes.bool
 }
 
 export default BasesLocalesList

--- a/components/bases-locales-list/index.js
+++ b/components/bases-locales-list/index.js
@@ -2,7 +2,6 @@ import React, {useState, useCallback} from 'react'
 import PropTypes from 'prop-types'
 import Router from 'next/router'
 import {Pane, Table, Paragraph} from 'evergreen-ui'
-import {orderBy} from 'lodash'
 
 import {getBalAccess, getBalToken, removeBalAccess} from '../../lib/tokens'
 
@@ -14,7 +13,7 @@ import {listBasesLocales, removeBaseLocale} from '../../lib/bal-api'
 import DeleteWarning from '../delete-warning'
 import BaseLocaleCard from './base-locale-card'
 
-function BasesLocalesList({basesLocales, updateBasesLocales, all}) {
+function BasesLocalesList({basesLocales, updateBasesLocales, sortBal}) {
   const [toRemove, setToRemove] = useState(null)
 
   const [setError] = useError(null)
@@ -94,7 +93,7 @@ function BasesLocalesList({basesLocales, updateBasesLocales, all}) {
               </Table.Row>
             )}
             <Table.Body background='tint1'>
-              {orderBy(filtered, [all ? filter => filter.nom.toLowerCase() : '_updated'], [all ? 'asc' : 'desc']).map(bal => (
+              {sortBal(filtered).map(bal => (
                 <BaseLocaleCard
                   key={bal._id}
                   baseLocale={bal}
@@ -123,13 +122,13 @@ BasesLocalesList.getInitialProps = async () => {
 
 BasesLocalesList.defaultProps = {
   updateBasesLocales: null,
-  all: false
+  sortBal: null
 }
 
 BasesLocalesList.propTypes = {
   basesLocales: PropTypes.array.isRequired,
   updateBasesLocales: PropTypes.func,
-  all: PropTypes.bool
+  sortBal: PropTypes.func
 }
 
 export default BasesLocalesList

--- a/components/bases-locales-list/index.js
+++ b/components/bases-locales-list/index.js
@@ -4,6 +4,7 @@ import Router from 'next/router'
 import {Pane, Table, Paragraph} from 'evergreen-ui'
 
 import {getBalAccess, getBalToken, removeBalAccess} from '../../lib/tokens'
+import {sortBalByUpdate} from '../../lib/sort-bal'
 
 import useFuse from '../../hooks/fuse'
 import useError from '../../hooks/error'
@@ -122,7 +123,7 @@ BasesLocalesList.getInitialProps = async () => {
 
 BasesLocalesList.defaultProps = {
   updateBasesLocales: null,
-  sortBal: null
+  sortBal: sortBalByUpdate
 }
 
 BasesLocalesList.propTypes = {

--- a/components/user-bases-locales.js
+++ b/components/user-bases-locales.js
@@ -7,7 +7,6 @@ import {expandWithPublished} from '../helpers/bases-locales'
 
 import {getBalAccess} from '../lib/tokens'
 import {getBaseLocale} from '../lib/bal-api'
-import {sortBalByUpdate} from '../lib/sort-bal'
 
 import BasesLocalesList from './bases-locales-list'
 
@@ -49,7 +48,7 @@ function UserBasesLocales() {
   return (
     <>
       {basesLocales.length > 0 ? (
-        <BasesLocalesList basesLocales={basesLocales} updateBasesLocales={setBalAccess} sortBal={sortBalByUpdate} />
+        <BasesLocalesList basesLocales={basesLocales} updateBasesLocales={setBalAccess} />
       ) : (
         <Button height={40} appearance='primary' margin='auto' iconBefore={PlusIcon} onClick={() => Router.push('/new')}>Créer une Base Adresse Locale</Button>
       )}

--- a/components/user-bases-locales.js
+++ b/components/user-bases-locales.js
@@ -1,22 +1,19 @@
 import React, {useState, useEffect} from 'react'
 import Router from 'next/router'
 import {Pane, Spinner, Button, PlusIcon} from 'evergreen-ui'
-import {map, orderBy} from 'lodash'
+import {map} from 'lodash'
 
 import {expandWithPublished} from '../helpers/bases-locales'
 
 import {getBalAccess} from '../lib/tokens'
 import {getBaseLocale} from '../lib/bal-api'
+import {sortBalByUpdate} from '../lib/sort-bal'
 
 import BasesLocalesList from './bases-locales-list'
 
 function UserBasesLocales() {
   const [basesLocales, setBasesLocales] = useState(null)
   const [balAccess, setBalAccess] = useState(getBalAccess())
-
-  function sortBalByUpdate(array) {
-    return orderBy(array, ['_updated'], ['desc'])
-  }
 
   useEffect(() => {
     const getUserBals = async () => {

--- a/components/user-bases-locales.js
+++ b/components/user-bases-locales.js
@@ -1,7 +1,7 @@
 import React, {useState, useEffect} from 'react'
 import Router from 'next/router'
 import {Pane, Spinner, Button, PlusIcon} from 'evergreen-ui'
-import {map} from 'lodash'
+import {map, orderBy} from 'lodash'
 
 import {expandWithPublished} from '../helpers/bases-locales'
 
@@ -13,6 +13,10 @@ import BasesLocalesList from './bases-locales-list'
 function UserBasesLocales() {
   const [basesLocales, setBasesLocales] = useState(null)
   const [balAccess, setBalAccess] = useState(getBalAccess())
+
+  function sortBalByUpdate(array) {
+    return orderBy(array, ['_updated'], ['desc'])
+  }
 
   useEffect(() => {
     const getUserBals = async () => {
@@ -48,7 +52,7 @@ function UserBasesLocales() {
   return (
     <>
       {basesLocales.length > 0 ? (
-        <BasesLocalesList basesLocales={basesLocales} updateBasesLocales={setBalAccess} />
+        <BasesLocalesList basesLocales={basesLocales} updateBasesLocales={setBalAccess} sortBal={sortBalByUpdate} />
       ) : (
         <Button height={40} appearance='primary' margin='auto' iconBefore={PlusIcon} onClick={() => Router.push('/new')}>Créer une Base Adresse Locale</Button>
       )}

--- a/lib/sort-bal.js
+++ b/lib/sort-bal.js
@@ -1,0 +1,9 @@
+import {orderBy} from 'lodash'
+
+export function sortBalByUpdate(array) {
+  return orderBy(array, ['_updated'], ['desc'])
+}
+
+export function sortBalByName(array) {
+  return orderBy(array, [array => array.nom.toLowerCase()])
+}

--- a/pages/all.js
+++ b/pages/all.js
@@ -24,7 +24,7 @@ function All({basesLocales}) {
       </Pane>
 
       <Pane flex={1} overflowY='scroll'>
-        <BasesLocalesList basesLocales={basesLocales} />
+        <BasesLocalesList all basesLocales={basesLocales} />
       </Pane>
 
       <Pane borderTop marginTop='auto' padding={16}>

--- a/pages/all.js
+++ b/pages/all.js
@@ -2,11 +2,11 @@ import React, {useCallback} from 'react'
 import PropTypes from 'prop-types'
 import Router from 'next/router'
 import {Pane, Heading, Paragraph, Button} from 'evergreen-ui'
-import {orderBy} from 'lodash'
 
 import {expandWithPublished} from '../helpers/bases-locales'
 
 import {listBasesLocales} from '../lib/bal-api'
+import {sortBalByName} from '../lib/sort-bal'
 
 import BasesLocalesList from '../components/bases-locales-list'
 
@@ -14,10 +14,6 @@ function All({basesLocales}) {
   const onCreate = useCallback(() => {
     Router.push('/new')
   }, [])
-
-  function sortBalByName(array) {
-    return orderBy(array, [array => array.nom.toLowerCase()])
-  }
 
   return (
     <>

--- a/pages/all.js
+++ b/pages/all.js
@@ -2,6 +2,7 @@ import React, {useCallback} from 'react'
 import PropTypes from 'prop-types'
 import Router from 'next/router'
 import {Pane, Heading, Paragraph, Button} from 'evergreen-ui'
+import {orderBy} from 'lodash'
 
 import {expandWithPublished} from '../helpers/bases-locales'
 
@@ -14,6 +15,10 @@ function All({basesLocales}) {
     Router.push('/new')
   }, [])
 
+  function sortBalByName(array) {
+    return orderBy(array, [array => array.nom.toLowerCase()])
+  }
+
   return (
     <>
       <Pane padding={16} backgroundColor='white'>
@@ -24,7 +29,7 @@ function All({basesLocales}) {
       </Pane>
 
       <Pane flex={1} overflowY='scroll'>
-        <BasesLocalesList all basesLocales={basesLocales} />
+        <BasesLocalesList basesLocales={basesLocales} sortBal={sortBalByName} />
       </Pane>
 
       <Pane borderTop marginTop='auto' padding={16}>


### PR DESCRIPTION
> fix #271 

Sur la page d'accueil, les Bases Adresse Locales sont désormais triées par date de mise à jour.

Sur la page `all`, elles sont triées par ordre alphabétique.