### PR TITLE
Résout le problème d'assignation du numéro au clique lors du mode édition

### DIFF
--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -152,7 +152,7 @@ function NumeroEditor({initialVoie, initialValue, onSubmit, onCancel}) {
     resetType(position ? position.type : 'entrée')
     resetComment(comment ? comment : '')
     setError(null)
-  }, [initialValue]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [position, resetNumero, resetSuffixe, resetType, resetComment, setError, initialValue])
 
   return (
     <Pane is='form' onSubmit={onFormSubmit}>

--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -27,10 +27,10 @@ function NumeroEditor({initialVoie, initialValue, onSubmit, onCancel}) {
   const [voie, setVoie] = useState(initialVoie)
 
   const [isLoading, setIsLoading] = useState(false)
-  const [numero, onNumeroChange] = useInput(initialValue ? initialValue.numero : '')
-  const [suffixe, onSuffixeChange] = useInput(initialValue ? initialValue.suffixe : '')
-  const [type, onTypeChange] = useInput(position ? position.type : 'entrée')
-  const [comment, onCommentChange] = useInput(initialValue ? initialValue.comment : '')
+  const [numero, onNumeroChange, resetNumero] = useInput(initialValue ? initialValue.numero : '')
+  const [suffixe, onSuffixeChange, resetSuffixe] = useInput(initialValue ? initialValue.suffixe : '')
+  const [type, onTypeChange, resetType] = useInput(position ? position.type : 'entrée')
+  const [comment, onCommentChange, resetComment] = useInput(initialValue ? initialValue.comment : '')
   const [error, setError] = useState()
   const focusRef = useFocus()
 
@@ -144,6 +144,15 @@ function NumeroEditor({initialVoie, initialValue, onSubmit, onCancel}) {
   useEffect(() => {
     setOverrideText(numero || numeroSuggestion)
   }, [numeroSuggestion, numero, setOverrideText])
+
+  useEffect(() => {
+    const {numero, suffixe, comment} = initialValue || {}
+    resetNumero(numero)
+    resetSuffixe(suffixe ? suffixe : '')
+    resetType(position ? position.type : 'entrée')
+    resetComment(comment ? comment : '')
+    setError(null)
+  }, [initialValue]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <Pane is='form' onSubmit={onFormSubmit}>

--- a/hooks/input.js
+++ b/hooks/input.js
@@ -7,8 +7,8 @@ export function useInput(initialValue) {
     setValue(e.target.value)
   }, [])
 
-  const resetInput = useCallback(() => {
-    setValue(initialValue || '')
+  const resetInput = useCallback(forcedValue => {
+    setValue(forcedValue || initialValue || '')
   }, [initialValue])
 
   return [value, onChange, resetInput]


### PR DESCRIPTION
Resolves #283 

- Ajout de l'attribut `name` aux champs du formulaire
- Utilisation de `useState` à la place de `useInput`


https://user-images.githubusercontent.com/45098730/106280658-7d066e80-623e-11eb-8143-8e2905980fae.mp4

