### PR TITLE
Corrections concernant le complément du nom de voie

### DIFF
--- a/components/map/hooks/layers.js
+++ b/components/map/hooks/layers.js
@@ -3,7 +3,7 @@ import {useMemo} from 'react'
 import {getVoiesLabelLayer, getVoieTraceLayer} from '../layers/voies'
 import {getNumerosPointLayer, getNumerosLabelLayer} from '../layers/numeros'
 
-function useLayers(voie, sources, style) {
+function useLayers(voie, sources, style, isComplementEnabled) {
   return useMemo(() => {
     const hasNumeros = sources.find(({name}) => name === 'positions')
     const hasVoies = sources.find(({name}) => name === 'voies')
@@ -21,12 +21,12 @@ function useLayers(voie, sources, style) {
 
     if (!voie && hasVoies) {
       layers.push(
-        getVoiesLabelLayer(style)
+        getVoiesLabelLayer(style, isComplementEnabled)
       )
     }
 
     return layers
-  }, [voie, sources, style])
+  }, [voie, sources, style, isComplementEnabled])
 }
 
 export default useLayers

--- a/components/map/layers/voies.js
+++ b/components/map/layers/voies.js
@@ -1,4 +1,4 @@
-export function getVoiesLabelLayer(style) {
+export function getVoiesLabelLayer(style, isComplementEnabled) {
   const layer = {
     id: 'voie-label',
     interactive: true,
@@ -22,12 +22,12 @@ export function getVoiesLabelLayer(style) {
       }
     },
     layout: {
-      'text-field': [
+      'text-field': isComplementEnabled ? [
         'case',
         ['has', 'complement'],
         ['concat', ['get', 'nomVoie'], '\n(', ['get', 'complement'], ')'],
         ['get', 'nomVoie']
-      ],
+      ] : ['get', 'nomVoie'],
       'text-anchor': 'top',
       'text-size': {
         base: 1,

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -106,7 +106,7 @@ function Map({interactive, style: defaultStyle, commune, voie}) {
 
   const sources = useSources(voie, hovered, editingId)
   const bounds = useBounds(commune, voie)
-  const layers = useLayers(voie, sources, style)
+  const layers = useLayers(voie, sources, style, baseLocale.enableComplement)
 
   const mapRef = useCallback(ref => {
     if (ref) {

--- a/pages/bal/voie-heading.js
+++ b/pages/bal/voie-heading.js
@@ -62,7 +62,7 @@ const VoieHeading = ({defaultVoie}) => {
           onMouseEnter={() => setHovered(true)}
           onMouseLeave={() => setHovered(false)}
         >
-          {getFullVoieName(voie)}
+          {getFullVoieName(voie, Boolean(baseLocale.enableComplement))}
           <EditIcon
             marginBottom={-2}
             marginLeft={8}

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -322,7 +322,6 @@ Voie.propTypes = {
   voie: PropTypes.shape({
     _id: PropTypes.string.isRequired,
     nom: PropTypes.string.isRequired,
-    complement: PropTypes.string,
     positions: PropTypes.array.isRequired
   }).isRequired,
   defaultNumeros: PropTypes.array


### PR DESCRIPTION
- Cache le complément de voie sur la carte quand l'option est désactivée (Fix #298)
- Afficher le complément de voie dans l'entête de la voie