### PR TITLE
Masque le bouton de création d'adresse en mode édition.

### DIFF
--- a/components/map/control.js
+++ b/components/map/control.js
@@ -2,7 +2,7 @@ import React, {useCallback} from 'react'
 import PropTypes from 'prop-types'
 import {Pane, Tooltip, Position, IconButton} from 'evergreen-ui'
 
-function Control({enabled, icon, enabledHint, disabledHint, onChange}) {
+function Control({enabled, icon, enabledHint, disabledHint, onChange, disabled}) {
   const onToggle = useCallback(e => {
     e.stopPropagation()
     onChange(enabled => !enabled)
@@ -12,17 +12,16 @@ function Control({enabled, icon, enabledHint, disabledHint, onChange}) {
     <>
       <Tooltip
         position={Position.LEFT}
-        background={enabled ? '#e1e1e1' : null}
+        isShown={disabled ? false : null}
         content={enabled ? enabledHint : disabledHint}
       >
         <Pane
-          is='button'
           className='mapboxgl-ctrl-icon mapboxgl-ctrl-enabled'
-          onClick={onToggle}
+          padding={0}
+          onClick={disabled ? null : onToggle}
         >
-          <IconButton icon={icon} />
+          <IconButton icon={icon} opacity={`${disabled ? '0.7' : null}`} />
         </Pane>
-
       </Tooltip>
       {/* Unifying MapboxGL and Evergreen style */}
       <style jsx global>{`
@@ -36,6 +35,7 @@ function Control({enabled, icon, enabledHint, disabledHint, onChange}) {
 
 Control.propTypes = {
   enabled: PropTypes.bool,
+  disabled: PropTypes.bool,
   icon: PropTypes.string.isRequired,
   enabledHint: PropTypes.string.isRequired,
   disabledHint: PropTypes.string.isRequired,
@@ -43,7 +43,8 @@ Control.propTypes = {
 }
 
 Control.defaultProps = {
-  enabled: true
+  enabled: true,
+  disabled: false
 }
 
 export default Control

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -99,10 +99,19 @@ function Map({interactive, style: defaultStyle, commune, voie}) {
 
   const [hoverPos, setHoverPos] = useState(null)
 
-  const {baseLocale, numeros, reloadNumeros, toponymes, reloadVoies, editingId, setEditingId} = useContext(BalDataContext)
   const {modeId} = useContext(DrawContext)
   const {enableMarker, disableMarker} = useContext(MarkerContext)
   const {token} = useContext(TokenContext)
+  const {
+    baseLocale,
+    numeros,
+    reloadNumeros,
+    toponymes,
+    reloadVoies,
+    editingId,
+    setEditingId,
+    inEdition,
+    setInEdition} = useContext(BalDataContext)
 
   const sources = useSources(voie, hovered, editingId)
   const bounds = useBounds(commune, voie)
@@ -236,11 +245,13 @@ function Map({interactive, style: defaultStyle, commune, voie}) {
 
   useEffect(() => {
     if (openForm) {
+      setInEdition(true)
       enableMarker()
     } else if (!openForm && !editingId) {
+      setInEdition(false)
       disableMarker()
     }
-  }, [openForm, disableMarker, enableMarker, editingId])
+  }, [openForm, disableMarker, enableMarker, editingId, setInEdition])
 
   return (
     <Pane display='flex' flexDirection='column' flex={1}>
@@ -309,7 +320,7 @@ function Map({interactive, style: defaultStyle, commune, voie}) {
               />
             )}
 
-            {token && commune && (
+            {token && commune && !inEdition && !editingId && (
               <Control
                 icon={MapMarkerIcon}
                 enabled={openForm}

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -304,10 +304,13 @@ function Map({interactive, style: defaultStyle, commune, voie}) {
 
           <Pane
             position='absolute'
-            className='mapboxgl-ctrl-group mapboxgl-ctrl'
+            display='flex'
+            flexDirection='column'
             top={88}
-            right={16}
+            right={14}
             zIndex={2}
+            background={(inEdition || editingId) ? 'overlay' : null}
+            className='mapboxgl-ctrl-group'
           >
 
             {(voie || (toponymes && toponymes.length > 0)) && (
@@ -320,12 +323,13 @@ function Map({interactive, style: defaultStyle, commune, voie}) {
               />
             )}
 
-            {token && commune && !inEdition && !editingId && (
+            {token && commune && (
               <Control
                 icon={MapMarkerIcon}
                 enabled={openForm}
                 enabledHint='Annuler'
                 disabledHint='Créer une adresse'
+                disabled={inEdition || editingId}
                 onChange={setOpenForm}
               />
             )}

--- a/contexts/bal-data.js
+++ b/contexts/bal-data.js
@@ -16,6 +16,7 @@ export const BalDataContextProvider = React.memo(({balId, codeCommune, idVoie, .
   const [voies, setVoies] = useState()
   const [voie, setVoie] = useState()
   const [baseLocale, setBaseLocal] = useState({})
+  const [inEdition, setInEdition] = useState(false)
 
   const {token} = useContext(TokenContext)
 
@@ -115,7 +116,9 @@ export const BalDataContextProvider = React.memo(({balId, codeCommune, idVoie, .
         setEditingId,
         reloadNumeros,
         reloadVoies,
-        reloadBaseLocale
+        reloadBaseLocale,
+        inEdition,
+        setInEdition
       }}
       {...props}
     />

--- a/pages/bal/commune.js
+++ b/pages/bal/commune.js
@@ -31,7 +31,9 @@ const Commune = React.memo(({commune, defaultVoies}) => {
     voies,
     reloadVoies,
     editingId,
-    setEditingId
+    setEditingId,
+    inEdition,
+    setInEdition
   } = useContext(BalDataContext)
 
   useHelp(2)
@@ -69,11 +71,13 @@ const Commune = React.memo(({commune, defaultVoies}) => {
     await reloadVoies()
 
     setIsAdding(false)
-  }, [baseLocale, commune, reloadVoies, token])
+    setInEdition(false)
+  }, [baseLocale, commune, reloadVoies, token, setInEdition])
 
   const onEnableAdding = useCallback(() => {
     setIsAdding(true)
-  }, [])
+    setInEdition(true)
+  }, [setInEdition])
 
   const onEnableEditing = useCallback(async idVoie => {
     const numeros = await getNumeros(idVoie)
@@ -113,7 +117,8 @@ const Commune = React.memo(({commune, defaultVoies}) => {
   const onCancel = useCallback(() => {
     setIsAdding(false)
     setEditingId(null)
-  }, [setEditingId])
+    setInEdition(false)
+  }, [setEditingId, setInEdition])
 
   useEffect(() => {
     if (!editingId) {
@@ -164,7 +169,7 @@ const Commune = React.memo(({commune, defaultVoies}) => {
               iconBefore={AddIcon}
               appearance='primary'
               intent='success'
-              disabled={isAdding || isPopulating || Boolean(editingId)}
+              disabled={isAdding || isPopulating || Boolean(editingId) || inEdition}
               onClick={onEnableAdding}
             >
               Ajouter une voie

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -32,7 +32,9 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
     numeros,
     reloadNumeros,
     editingId,
-    setEditingId
+    setEditingId,
+    inEdition,
+    setInEdition
   } = useContext(BalDataContext)
 
   useHelp(3)
@@ -90,16 +92,19 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
     await reloadNumeros()
 
     setIsAdding(false)
-  }, [voie, reloadNumeros, token])
+    setInEdition(false)
+  }, [voie, reloadNumeros, token, setInEdition])
 
   const onEnableAdding = useCallback(() => {
     setIsAdding(true)
-  }, [])
+    setInEdition(true)
+  }, [setInEdition])
 
   const onEnableEditing = useCallback(idNumero => {
     setIsAdding(false)
+    setInEdition(false)
     setEditingId(idNumero)
-  }, [setEditingId])
+  }, [setEditingId, setInEdition])
 
   const onEdit = useCallback(async ({numero, voie, suffixe, comment, positions}) => {
     await editNumero(editingId, {
@@ -151,8 +156,9 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
 
   const onCancel = useCallback(() => {
     setIsAdding(false)
+    setInEdition(false)
     setEditingId(null)
-  }, [setEditingId])
+  }, [setEditingId, setInEdition])
 
   useEffect(() => {
     if (editingId) {
@@ -193,7 +199,7 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
               iconBefore={AddIcon}
               appearance='primary'
               intent='success'
-              disabled={isAdding}
+              disabled={isAdding || inEdition}
               onClick={onEnableAdding}
             >
               Ajouter un numéro


### PR DESCRIPTION
Le bouton "Ajouter une adresse", disponible sur la carte, est maintenant masqué lorsqu'on édite une voie ou un numéro.

Fix #301 
