### PR TITLE
Désactive l'édition quand une édition ou une création est déjà en cours

### DIFF
--- a/components/map/control.js
+++ b/components/map/control.js
@@ -1,41 +1,40 @@
 import React, {useCallback} from 'react'
 import PropTypes from 'prop-types'
-import {Pane, Tooltip, Position, IconButton} from 'evergreen-ui'
+import {Pane, Tooltip, Position, Icon} from 'evergreen-ui'
 
-function Control({enabled, icon, enabledHint, disabledHint, onChange}) {
+function Control({enabled, isDisabled, icon, enabledHint, disabledHint, onChange}) {
   const onToggle = useCallback(e => {
     e.stopPropagation()
     onChange(enabled => !enabled)
   }, [onChange])
 
-  return (
-    <>
-      <Tooltip
-        position={Position.LEFT}
-        background={enabled ? '#e1e1e1' : null}
-        content={enabled ? enabledHint : disabledHint}
-      >
-        <Pane
-          is='button'
-          className='mapboxgl-ctrl-icon mapboxgl-ctrl-enabled'
-          onClick={onToggle}
-        >
-          <IconButton icon={icon} />
-        </Pane>
+  if (isDisabled) {
+    return (
+      <Pane is='button' className='mapboxgl-ctrl-icon mapboxgl-ctrl-enabled'>
+        <Icon icon={icon} color='muted' />
+      </Pane>
+    )
+  }
 
-      </Tooltip>
-      {/* Unifying MapboxGL and Evergreen style */}
-      <style jsx global>{`
-        .ub-w_14px.ub-h_14px.ub-box-szg_border-box {
-          fill: black !important;
-        }
-      `}</style>
-    </>
+  return (
+    <Tooltip
+      position={Position.LEFT}
+      content={enabled ? enabledHint : disabledHint}
+    >
+      <Pane
+        is='button'
+        className='mapboxgl-ctrl-icon mapboxgl-ctrl-enabled'
+        onClick={onToggle}
+      >
+        <Icon icon={icon} color={isDisabled ? 'muted' : 'black'} />
+      </Pane>
+    </Tooltip>
   )
 }
 
 Control.propTypes = {
   enabled: PropTypes.bool,
+  isDisabled: PropTypes.bool,
   icon: PropTypes.string.isRequired,
   enabledHint: PropTypes.string.isRequired,
   disabledHint: PropTypes.string.isRequired,
@@ -43,7 +42,8 @@ Control.propTypes = {
 }
 
 Control.defaultProps = {
-  enabled: true
+  enabled: true,
+  isDisabled: false
 }
 
 export default Control

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -99,7 +99,17 @@ function Map({interactive, style: defaultStyle, commune, voie}) {
 
   const [hoverPos, setHoverPos] = useState(null)
 
-  const {baseLocale, numeros, reloadNumeros, toponymes, reloadVoies, editingId, setEditingId} = useContext(BalDataContext)
+  const {
+    baseLocale,
+    numeros,
+    reloadNumeros,
+    toponymes,
+    reloadVoies,
+    editingId,
+    setEditingId,
+    setIsEditing,
+    isEditing
+  } = useContext(BalDataContext)
   const {modeId} = useContext(DrawContext)
   const {enableMarker, disableMarker} = useContext(MarkerContext)
   const {token} = useContext(TokenContext)
@@ -145,7 +155,7 @@ function Map({interactive, style: defaultStyle, commune, voie}) {
   const onClick = useCallback(event => {
     const feature = event.features && event.features[0]
 
-    if (feature && feature.properties.idVoie) {
+    if (feature && feature.properties.idVoie && !isEditing) {
       const {idVoie} = feature.properties
       if (feature.layer.id === 'voie-trace-line' && idVoie === voie._id) {
         setEditingId(voie._id)
@@ -158,7 +168,7 @@ function Map({interactive, style: defaultStyle, commune, voie}) {
     }
 
     setShowContextMenu(null)
-  }, [baseLocale, commune, setEditingId, voie])
+  }, [baseLocale, commune, setEditingId, isEditing, voie])
 
   const onHover = useCallback(event => {
     const feature = event.features && event.features[0]
@@ -229,18 +239,14 @@ function Map({interactive, style: defaultStyle, commune, voie}) {
   }, [map, bounds])
 
   useEffect(() => {
-    if (editingId) {
-      setOpenForm(false)
-    }
-  }, [editingId])
-
-  useEffect(() => {
     if (openForm) {
+      setIsEditing(true)
       enableMarker()
-    } else if (!openForm && !editingId) {
+    } else {
+      setIsEditing(false)
       disableMarker()
     }
-  }, [openForm, disableMarker, enableMarker, editingId])
+  }, [openForm, disableMarker, enableMarker, setIsEditing])
 
   return (
     <Pane display='flex' flexDirection='column' flex={1}>
@@ -313,7 +319,7 @@ function Map({interactive, style: defaultStyle, commune, voie}) {
               <Control
                 icon={MapMarkerIcon}
                 enabled={openForm}
-                isDisabled={editingId}
+                isDisabled={isEditing}
                 enabledHint='Annuler'
                 disabledHint='Créer une adresse'
                 onChange={setOpenForm}

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -232,7 +232,7 @@ function Map({interactive, style: defaultStyle, commune, voie}) {
     if (editingId) {
       setOpenForm(false)
     }
-  }, [editingId, openForm])
+  }, [editingId])
 
   useEffect(() => {
     if (openForm) {
@@ -313,6 +313,7 @@ function Map({interactive, style: defaultStyle, commune, voie}) {
               <Control
                 icon={MapMarkerIcon}
                 enabled={openForm}
+                isDisabled={editingId}
                 enabledHint='Annuler'
                 disabledHint='Créer une adresse'
                 onChange={setOpenForm}

--- a/components/map/numero-marker.js
+++ b/components/map/numero-marker.js
@@ -19,13 +19,15 @@ function NumeroMarker({numero, colorSeed, showLabel, showContextMenu, setShowCon
 
   const {token} = useContext(TokenContext)
   const {marker} = useContext(MarkerContext)
-  const {editingId, setEditingId, reloadNumeros} = useContext(BalDataContext)
+  const {editingId, setEditingId, isEditing, reloadNumeros} = useContext(BalDataContext)
 
   const onEnableEditing = useCallback(e => {
     e.stopPropagation()
 
-    setEditingId(numero._id)
-  }, [setEditingId, numero])
+    if (!isEditing) {
+      setEditingId(numero._id)
+    }
+  }, [setEditingId, isEditing, numero])
 
   const position = numero.positions[0]
 

--- a/components/map/toponyme-marker.js
+++ b/components/map/toponyme-marker.js
@@ -18,13 +18,15 @@ function ToponymeMarker({toponyme, showLabel, showContextMenu, setShowContextMen
 
   const {token} = useContext(TokenContext)
   const {marker} = useContext(MarkerContext)
-  const {baseLocale, editingId, setEditingId, reloadVoies} = useContext(BalDataContext)
+  const {baseLocale, editingId, setEditingId, isEditing, reloadVoies} = useContext(BalDataContext)
 
   const onEnableEditing = useCallback(e => {
     e.stopPropagation()
 
-    setEditingId(toponyme._id)
-  }, [toponyme._id, setEditingId])
+    if (!isEditing) {
+      setEditingId(toponyme._id)
+    }
+  }, [isEditing, toponyme._id, setEditingId])
 
   const position = toponyme.positions[0]
 

--- a/components/table-row.js
+++ b/components/table-row.js
@@ -8,18 +8,18 @@ import BalDataContext from '../contexts/bal-data'
 const TableRow = React.memo(({id, code, positions, label, comment, secondary, isSelectable, onSelect, onEdit, onRemove, handleSelect, isSelected}) => {
   const [hovered, setHovered] = useState(false)
   const {token} = useContext(TokenContext)
-  const {numeros} = useContext(BalDataContext)
+  const {numeros, isEditing} = useContext(BalDataContext)
   const {type} = positions[0] || {}
 
   const onClick = useCallback(e => {
-    if (e.target.closest('[data-editable]') && !code) { // Not a commune
+    if (e.target.closest('[data-editable]') && !isEditing && !code) { // Not a commune
       onEdit(id)
     } else if (isSelectable) {
       if (e.target.closest('[data-browsable]')) {
         onSelect(id)
       }
     }
-  }, [code, id, isSelectable, onEdit, onSelect])
+  }, [code, id, isSelectable, isEditing, onEdit, onSelect])
 
   const _onEdit = useCallback(() => {
     onEdit(id)
@@ -45,7 +45,7 @@ const TableRow = React.memo(({id, code, positions, label, comment, secondary, is
 
   return (
     <Table.Row isSelectable={isSelectable} style={{backgroundColor: hovered ? '#f5f6f7' : ''}} onClick={onClick}>
-      {token && numeros && numeros.length > 1 && (
+      {token && !isEditing && numeros && numeros.length > 1 && (
         <Table.Cell flex='0 1 1'>
           <Checkbox
             checked={isSelected}
@@ -60,11 +60,11 @@ const TableRow = React.memo(({id, code, positions, label, comment, secondary, is
         <Table.TextCell
           data-editable
           flex='0 1 1'
-          style={{cursor: onEdit ? 'text' : 'default'}}
+          style={{cursor: onEdit && !isEditing ? 'text' : 'default'}}
           onMouseEnter={() => _onMouseEnter(id)}
           onMouseLeave={_onMouseLeave}
         >
-          {label} {hovered && (
+          {label} {hovered && !isEditing && (
             <EditIcon marginBottom={-4} marginLeft={8} />
           )}
         </Table.TextCell>
@@ -104,7 +104,7 @@ const TableRow = React.memo(({id, code, positions, label, comment, secondary, is
                       Consulter
                     </Menu.Item>
                   )}
-                  {onEdit && (
+                  {onEdit && !isEditing && (
                     <Menu.Item icon={EditIcon} onSelect={_onEdit}>
                       Modifier
                     </Menu.Item>

--- a/contexts/bal-data.js
+++ b/contexts/bal-data.js
@@ -10,6 +10,7 @@ import TokenContext from './token'
 const BalDataContext = React.createContext()
 
 export const BalDataContextProvider = React.memo(({balId, codeCommune, idVoie, ...props}) => {
+  const [isEditing, setIsEditing] = useState(false)
   const [editingId, _setEditingId] = useState()
   const [geojson, setGeojson] = useState()
   const [numeros, setNumeros] = useState()
@@ -74,6 +75,7 @@ export const BalDataContextProvider = React.memo(({balId, codeCommune, idVoie, .
   const setEditingId = useCallback(editingId => {
     if (token) {
       _setEditingId(editingId)
+      setIsEditing(Boolean(editingId))
     }
   }, [token])
 
@@ -90,20 +92,17 @@ export const BalDataContextProvider = React.memo(({balId, codeCommune, idVoie, .
   }, [reloadGeojson, voies, numeros, setEditingId])
 
   useEffect(() => {
+    setEditingId(null)
     reloadNumeros()
-  }, [reloadNumeros])
-
-  useEffect(() => {
     reloadVoies()
-  }, [reloadVoies])
-
-  useEffect(() => {
     reloadBaseLocale()
-  }, [reloadBaseLocale])
+  }, [setEditingId, reloadNumeros, reloadVoies, reloadBaseLocale])
 
   return (
     <BalDataContext.Provider
       value={{
+        isEditing,
+        setIsEditing,
         editingId,
         editingItem,
         geojson,

--- a/pages/bal/commune.js
+++ b/pages/bal/commune.js
@@ -31,7 +31,9 @@ const Commune = React.memo(({commune, defaultVoies}) => {
     voies,
     reloadVoies,
     editingId,
-    setEditingId
+    setEditingId,
+    isEditing,
+    setIsEditing
   } = useContext(BalDataContext)
 
   useHelp(2)
@@ -121,6 +123,10 @@ const Commune = React.memo(({commune, defaultVoies}) => {
     }
   }, [editingId])
 
+  useEffect(() => {
+    setIsEditing(isAdding)
+  }, [isAdding, setIsEditing])
+
   return (
     <>
       <DeleteWarning
@@ -164,7 +170,7 @@ const Commune = React.memo(({commune, defaultVoies}) => {
               iconBefore={AddIcon}
               appearance='primary'
               intent='success'
-              disabled={isAdding || isPopulating || Boolean(editingId)}
+              disabled={isAdding || isPopulating || Boolean(editingId) || isEditing}
               onClick={onEnableAdding}
             >
               Ajouter une voie
@@ -216,7 +222,7 @@ const Commune = React.memo(({commune, defaultVoies}) => {
               <TableRow
                 key={voie._id}
                 id={voie._id}
-                isSelectable={!isAdding && !isPopulating && !editingId && voie.positions.length === 0}
+                isSelectable={!isEditing && !isPopulating && voie.positions.length === 0}
                 label={getFullVoieName(voie, baseLocale.enableComplement)}
                 secondary={voie.positions.length === 1 ? 'Toponyme' : null}
                 onSelect={onSelect}

--- a/pages/bal/voie-heading.js
+++ b/pages/bal/voie-heading.js
@@ -14,12 +14,14 @@ const VoieHeading = ({defaultVoie}) => {
   const [voie, setVoie] = useState(defaultVoie)
   const [hovered, setHovered] = useState(false)
   const {token} = useContext(TokenContext)
-  const {baseLocale, editingId, setEditingId, reloadVoies, numeros} = useContext(BalDataContext)
+  const {baseLocale, editingId, setEditingId, isEditing, reloadVoies, numeros} = useContext(BalDataContext)
 
   const onEnableVoieEditing = useCallback(() => {
-    setEditingId(voie._id)
-    setHovered(false)
-  }, [setEditingId, voie._id])
+    if (!isEditing) {
+      setEditingId(voie._id)
+      setHovered(false)
+    }
+  }, [setEditingId, isEditing, voie._id])
 
   const onEditVoie = useCallback(async ({nom, typeNumerotation, trace, complement, positions}) => {
     const editedVoie = await editVoie(voie._id, {
@@ -57,17 +59,19 @@ const VoieHeading = ({defaultVoie}) => {
         />
       ) : (
         <Heading
-          style={{cursor: hovered ? 'text' : 'default'}}
+          style={{cursor: hovered && !isEditing ? 'text' : 'default'}}
           onClick={onEnableVoieEditing}
           onMouseEnter={() => setHovered(true)}
           onMouseLeave={() => setHovered(false)}
         >
           {getFullVoieName(voie, Boolean(baseLocale.enableComplement))}
-          <EditIcon
-            marginBottom={-2}
-            marginLeft={8}
-            color={hovered ? 'black' : 'muted'}
-          />
+          {!isEditing && (
+            <EditIcon
+              marginBottom={-2}
+              marginLeft={8}
+              color={hovered ? 'black' : 'muted'}
+            />
+          )}
         </Heading>
       )}
       {numeros && (

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -32,7 +32,9 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
     numeros,
     reloadNumeros,
     editingId,
-    setEditingId
+    setEditingId,
+    isEditing,
+    setIsEditing
   } = useContext(BalDataContext)
 
   useHelp(3)
@@ -172,6 +174,10 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
     }
   }, [voie])
 
+  useEffect(() => {
+    setIsEditing(isAdding)
+  }, [isAdding, setIsEditing])
+
   return (
     <>
       <VoieHeading defaultVoie={voie} />
@@ -193,7 +199,7 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
               iconBefore={AddIcon}
               appearance='primary'
               intent='success'
-              disabled={isAdding}
+              disabled={isAdding || isEditing}
               onClick={onEnableAdding}
             >
               Ajouter un numéro
@@ -283,7 +289,7 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
                   key={numero._id}
                   id={numero._id}
                   comment={numero.comment}
-                  isSelectable={!isAdding && !editingId && numero.positions.length > 1}
+                  isSelectable={!isEditing && numero.positions.length > 1}
                   label={numero.numeroComplet}
                   secondary={numero.positions.length > 1 ? `${numero.positions.length} positions` : null}
                   handleSelect={handleSelect}


### PR DESCRIPTION
Lorsqu'une édition ou une création est en cours sur une adresse, toute autre action d'édition sur un autre object est bloquée.

La possibilité de lancer plusieurs éditions ou création de manière simultanée provoque un nombre conséquent de bug pouvant aller jusqu'à faire planter l'application.

Cette PR rigidifie légèrement la fluidité de l'expérience utilisateur, mais assure un fonctionnement cohérent et corrige bon nombre de comportements improbable pouvant provoquer des erreurs. 

Remplace #305 
Fix #301
Fix #306 