### PR TITLE
Ajout d'une condition sur backend-adresse

### DIFF
--- a/lib/adresse-backend/index.js
+++ b/lib/adresse-backend/index.js
@@ -25,6 +25,10 @@ async function request(url, opts = {}) {
 }
 
 export async function getPublishedBasesLocales() {
+  if (!process.env.NEXT_PUBLIC_ADRESSE_BACKEND_URL) {
+    return []
+  }
+
   const items = await request('/publication/submissions/published')
   return items.filter(item => item.url)
 }


### PR DESCRIPTION
Ajouts d'une condition pour éviter tout problème avec `backend.adresse.data.gouv.fr` après l'incendie OVH.