### PR TITLE
Correction du fond de carte cadastral

### DIFF
--- a/components/map/styles/vector-cadastre.json
+++ b/components/map/styles/vector-cadastre.json
@@ -5428,7 +5428,7 @@
       "layout": {
         "text-field": "{code}",
         "text-font": [
-          "Lato Bold"
+          "Noto Sans Bold"
         ],
         "visibility": "visible"
       },
@@ -5449,7 +5449,7 @@
       "layout": {
         "text-field": "{numero}",
         "text-font": [
-          "Lato Bold"
+          "Noto Sans Bold"
         ],
         "text-allow-overlap": false,
         "visibility": "visible",


### PR DESCRIPTION
- Remplacement de la font `Lato` par `Noto Sans`