### PR TITLE
Modification du recentrage automatique de la carte

### DIFF
--- a/components/map/hooks/bounds.js
+++ b/components/map/hooks/bounds.js
@@ -36,7 +36,7 @@ function useBounds(commune, voie) {
     }
 
     return null
-  }, [geojson, commune, voie])
+  }, [commune, voie]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return useMemo(() => data ? bbox(data) : data, [data])
 }


### PR DESCRIPTION
### Context
Lors de l'ajout de numéro sur de longue voie, la carte se recentre sur l'assemble de la voie après chaque modification. Ce comportement est gênant car il modifie le zoom et déplace la carte obligeant l'utilisateur à recommencer son placement pour ajouter un nouveau numéro à la suite du premier.

------
Cette PR permet que le recentrage de la carte ne s'effectue que si le contexte (voie ou commune) change.