### PR TITLE
Nouvelle gestion des toponymes

### DIFF
--- a/components/bal/address-editor.js
+++ b/components/bal/address-editor.js
@@ -179,7 +179,7 @@ function AddressEditor({onSubmit, onCancel, isToponyme, setIsToponyme}) {
             marginLeft='1em'
             onChange={handleToponymeChange}
           >
-            <option value={null}>Pas de Toponyme</option>
+            <option value={null}>- Choisir un toponyme -</option>
             {sortBy(toponymes, t => normalizeSort(t.nom)).map(({_id, nom}) => (
               <option
                 key={_id}

--- a/components/bal/address-editor.js
+++ b/components/bal/address-editor.js
@@ -1,7 +1,7 @@
 import React, {useState, useMemo, useCallback, useContext, useEffect} from 'react'
 import PropTypes from 'prop-types'
 import {trimStart, trimEnd, sortBy} from 'lodash'
-import {Pane, Heading, TextInput, Button, Alert, Checkbox, Select, Text} from 'evergreen-ui'
+import {Pane, Heading, TextInput, Button, Alert, Checkbox, Select} from 'evergreen-ui'
 
 import {normalizeSort} from '../../lib/normalize'
 
@@ -198,7 +198,7 @@ function AddressEditor({onSubmit, onCancel, isToponyme, setIsToponyme}) {
         onChange={e => setIsToponyme(e.target.checked)}
       />
 
-      <PositionEditor isToponyme={isToponyme} />
+      <PositionEditor />
 
       {!isToponyme && (
         <Comment input={comment} onChange={onCommentChange} />

--- a/components/bal/address-editor.js
+++ b/components/bal/address-editor.js
@@ -179,7 +179,7 @@ function AddressEditor({onSubmit, onCancel, isToponyme, setIsToponyme}) {
             marginLeft='1em'
             onChange={handleToponymeChange}
           >
-            <option />
+            <option value={null}>Pas de Toponyme</option>
             {sortBy(toponymes, t => normalizeSort(t.nom)).map(({_id, nom}) => (
               <option
                 key={_id}

--- a/components/bal/address-editor.js
+++ b/components/bal/address-editor.js
@@ -1,7 +1,9 @@
 import React, {useState, useMemo, useCallback, useContext, useEffect} from 'react'
 import PropTypes from 'prop-types'
-import {trimStart, trimEnd} from 'lodash'
-import {Pane, Heading, TextInput, Button, Alert, Checkbox} from 'evergreen-ui'
+import {trimStart, trimEnd, sortBy} from 'lodash'
+import {Pane, Heading, TextInput, Button, Alert, Checkbox, Select, Text} from 'evergreen-ui'
+
+import {normalizeSort} from '../../lib/normalize'
 
 import MarkersContext from '../../contexts/markers'
 import BalDataContext from '../../contexts/bal-data'
@@ -16,13 +18,14 @@ import PositionEditor from './position-editor'
 import VoieSearch from './voie-search'
 
 function AddressEditor({onSubmit, onCancel, isToponyme, setIsToponyme}) {
-  const {voie} = useContext(BalDataContext)
+  const {voie, toponymes} = useContext(BalDataContext)
   const {markers, addMarker, disableMarkers, suggestedNumero, setOverrideText} = useContext(MarkersContext)
 
   const [isLoading, setIsLoading] = useState(false)
   const [input, onInputChange] = useInput('')
   const [selectedVoie, setSelectedVoie] = useState(voie)
   const [nomVoie, setNomVoie] = useState(voie ? voie.nom : '')
+  const [toponyme, setToponyme] = useState()
   const [suffixe, onSuffixeChange] = useInput('')
   const [comment, onCommentChange] = useInput('')
   const [error, setError] = useState()
@@ -49,14 +52,17 @@ function AddressEditor({onSubmit, onCancel, isToponyme, setIsToponyme}) {
 
     let voie
     let numero = null
+    let editedToponyme
+
     if (isToponyme) {
-      voie = {nom: input, positions}
+      editedToponyme = {nom: input, positions}
     } else {
       voie = selectedVoie || {
         nom: nomVoie
       }
       numero = {
         numero: Number(input),
+        toponyme: toponyme?._id,
         suffixe: suffixe.length > 0 ? suffixe : null,
         comment: comment.length > 0 ? comment : null,
         positions
@@ -64,13 +70,13 @@ function AddressEditor({onSubmit, onCancel, isToponyme, setIsToponyme}) {
     }
 
     try {
-      await onSubmit(voie, numero)
+      await onSubmit((isToponyme ? editedToponyme : voie), numero)
     } catch (error) {
       setError(error.message)
     }
 
     setIsLoading(false)
-  }, [input, nomVoie, comment, suffixe, markers, isToponyme, selectedVoie, onSubmit])
+  }, [input, nomVoie, comment, suffixe, markers, isToponyme, selectedVoie, onSubmit, toponyme])
 
   const onFormCancel = useCallback(e => {
     e.preventDefault()
@@ -86,6 +92,12 @@ function AddressEditor({onSubmit, onCancel, isToponyme, setIsToponyme}) {
 
     return 'Enregistrer'
   }, [isLoading])
+
+  const handleToponymeChange = e => {
+    const {value} = e.target
+
+    setToponyme(toponymes.find(({_id}) => _id === value))
+  }
 
   useEffect(() => {
     setSelectedVoie(isToponyme ? null : voie)
@@ -156,12 +168,28 @@ function AddressEditor({onSubmit, onCancel, isToponyme, setIsToponyme}) {
       </Pane>
 
       {!isToponyme && (
-        <VoieSearch
-          selectedVoie={selectedVoie}
-          nomVoie={nomVoie}
-          setNomVoie={e => setNomVoie(trimStart(trimEnd(e.target.value)))}
-          onSelect={onSelectVoie}
-        />
+        <Pane display='grid' gridTemplateColumns='1fr 3fr'>
+          <VoieSearch
+            selectedVoie={selectedVoie}
+            nomVoie={nomVoie}
+            setNomVoie={e => setNomVoie(trimStart(trimEnd(e.target.value)))}
+            onSelect={onSelectVoie}
+          />
+          <Select
+            marginLeft='1em'
+            onChange={handleToponymeChange}
+          >
+            <option />
+            {sortBy(toponymes, t => normalizeSort(t.nom)).map(({_id, nom}) => (
+              <option
+                key={_id}
+                value={_id}
+              >
+                {nom}
+              </option>
+            ))}
+          </Select>
+        </Pane>
       )}
 
       <Checkbox
@@ -170,9 +198,7 @@ function AddressEditor({onSubmit, onCancel, isToponyme, setIsToponyme}) {
         onChange={e => setIsToponyme(e.target.checked)}
       />
 
-      {markers.length > 0 && (
-        <PositionEditor isToponyme={isToponyme} />
-      )}
+      <PositionEditor isToponyme={isToponyme} />
 
       {!isToponyme && (
         <Comment input={comment} onChange={onCommentChange} />

--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -15,10 +15,10 @@ import useKeyEvent from '../../hooks/key-event'
 import Comment from '../comment'
 import PositionEditor from './position-editor'
 
-function NumeroEditor({initialVoie, initialValue, onSubmit, onCancel}) {
-  const {voies} = useContext(BalDataContext)
+function NumeroEditor({initialVoie, initialToponyme, initialValue, onSubmit, onCancel}) {
+  const {voies, toponymes} = useContext(BalDataContext)
 
-  const [voie, setVoie] = useState(initialVoie)
+  const [voie, setVoie] = useState(initialVoie || (initialValue && initialValue.voie[0]) || null)
 
   const [isLoading, setIsLoading] = useState(false)
   const [numero, onNumeroChange, resetNumero] = useInput(initialValue ? initialValue.numero : '')
@@ -42,7 +42,8 @@ function NumeroEditor({initialVoie, initialValue, onSubmit, onCancel}) {
 
     const body = {
       numero: Number(numero),
-      voie: voie._id,
+      voie: voie._id || null,
+      toponyme: initialToponyme ? initialToponyme._id : null,
       suffixe: suffixe.length > 0 ? suffixe.toLowerCase().trim() : null,
       comment: comment.length > 0 ? comment : null
     }
@@ -71,7 +72,7 @@ function NumeroEditor({initialVoie, initialValue, onSubmit, onCancel}) {
       setError(error.message)
       setIsLoading(false)
     }
-  }, [numero, voie, suffixe, comment, markers, onSubmit, disableMarkers])
+  }, [numero, voie, initialToponyme, suffixe, comment, markers, onSubmit, disableMarkers])
 
   const onFormCancel = useCallback(e => {
     e.preventDefault()
@@ -132,26 +133,46 @@ function NumeroEditor({initialVoie, initialValue, onSubmit, onCancel}) {
 
   return (
     <Pane is='form' onSubmit={onFormSubmit}>
-      {initialValue && (
-        <Pane display='flex'>
-          <SelectField
-            label='Voie'
-            flex={1}
-            marginBottom={16}
-            onChange={handleVoieChange}
-          >
-            {sortBy(voies, v => normalizeSort(v.nom)).map(({_id, nom}) => (
-              <option
-                key={_id}
-                selected={_id === initialValue.voie}
-                value={_id}
-              >
-                {nom}
-              </option>
-            ))}
-          </SelectField>
-        </Pane>
-      )}
+      <Pane display='flex'>
+        <SelectField
+          required
+          label='Voie'
+          flex={1}
+          marginBottom={16}
+          onChange={handleVoieChange}
+        >
+          <option />
+          {sortBy(voies, v => normalizeSort(v.nom)).map(({_id, nom}) => (
+            <option
+              key={_id}
+              selected={(initialVoie && _id === initialVoie._id) || (initialValue && _id === initialValue.voie[0]._id)}
+              value={_id}
+            >
+              {nom}
+            </option>
+          ))}
+        </SelectField>
+      </Pane>
+
+      <Pane display='flex'>
+        <SelectField
+          label='Toponyme'
+          flex={1}
+          marginBottom={16}
+          onChange={handleVoieChange}
+        >
+          <option />
+          {sortBy(toponymes, t => normalizeSort(t.nom)).map(({_id, nom}) => (
+            <option
+              key={_id}
+              selected={(initialToponyme && _id === initialToponyme._id) || (initialValue && _id === initialValue.toponyme)}
+              value={_id}
+            >
+              {nom}
+            </option>
+          ))}
+        </SelectField>
+      </Pane>
 
       <Pane display='flex'>
         <TextInput
@@ -234,13 +255,20 @@ NumeroEditor.propTypes = {
   initialVoie: PropTypes.shape({
     _id: PropTypes.string.isRequired,
     trace: PropTypes.object
-  }).isRequired,
+  }),
+  initialToponyme: PropTypes.shape({
+    _id: PropTypes.string,
+    commune: PropTypes.string,
+    nom: PropTypes.string,
+    positions: PropTypes.array
+  }),
   initialValue: PropTypes.shape({
     numero: PropTypes.number.isRequired,
     voie: PropTypes.string.isRequired,
     suffixe: PropTypes.string,
     comment: PropTypes.string,
-    positions: PropTypes.array
+    positions: PropTypes.array,
+    toponyme: PropTypes.string
   }),
   onSubmit: PropTypes.func.isRequired,
   onCancel: PropTypes.func
@@ -248,6 +276,8 @@ NumeroEditor.propTypes = {
 
 NumeroEditor.defaultProps = {
   initialValue: null,
+  initialVoie: null,
+  initialToponyme: null,
   onCancel: null
 }
 

--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -168,7 +168,7 @@ function NumeroEditor({initialVoie, initialToponyme, initialValue, onSubmit, onC
           marginBottom={16}
           onChange={handleToponymeChange}
         >
-          <option value={null}>{initialToponyme ? 'Aucun toponyme' : '- Choisir un toponyme -'}</option>
+          <option value={null}>{(initialToponyme || initialValue?.toponyme) ? 'Aucun toponyme' : '- Choisir un toponyme -'}</option>
           {sortBy(toponymes, t => normalizeSort(t.nom)).map(({_id, nom}) => (
             <option
               key={_id}

--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -148,7 +148,7 @@ function NumeroEditor({initialVoie, initialToponyme, initialValue, onSubmit, onC
           marginBottom={16}
           onChange={handleChange}
         >
-          <option />
+          <option value={null}>Pas de voie sélectionnée</option>
           {sortBy(voies, v => normalizeSort(v.nom)).map(({_id, nom}) => (
             <option
               key={_id}
@@ -168,7 +168,7 @@ function NumeroEditor({initialVoie, initialToponyme, initialValue, onSubmit, onC
           marginBottom={16}
           onChange={handleToponymeChange}
         >
-          <option />
+          <option value={null}>Pas de Toponyme</option>
           {sortBy(toponymes, t => normalizeSort(t.nom)).map(({_id, nom}) => (
             <option
               key={_id}

--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -148,7 +148,7 @@ function NumeroEditor({initialVoie, initialToponyme, initialValue, onSubmit, onC
           marginBottom={16}
           onChange={handleChange}
         >
-          <option value={null}>Pas de voie sélectionnée</option>
+          <option value={null}>- Choisir une voie -</option>
           {sortBy(voies, v => normalizeSort(v.nom)).map(({_id, nom}) => (
             <option
               key={_id}
@@ -168,7 +168,7 @@ function NumeroEditor({initialVoie, initialToponyme, initialValue, onSubmit, onC
           marginBottom={16}
           onChange={handleToponymeChange}
         >
-          <option value={null}>Pas de Toponyme</option>
+          <option value={null}>{initialToponyme ? 'Aucun toponyme' : '- Choisir un toponyme -'}</option>
           {sortBy(toponymes, t => normalizeSort(t.nom)).map(({_id, nom}) => (
             <option
               key={_id}

--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -19,6 +19,7 @@ function NumeroEditor({initialVoie, initialToponyme, initialValue, onSubmit, onC
   const {voies, toponymes} = useContext(BalDataContext)
 
   const [voie, setVoie] = useState(initialVoie || (initialValue && initialValue.voie[0]) || null)
+  const [toponyme, setToponyme] = useState(initialToponyme || (initialValue && initialValue.toponyme) || null)
 
   const [isLoading, setIsLoading] = useState(false)
   const [numero, onNumeroChange, resetNumero] = useInput(initialValue ? initialValue.numero : '')
@@ -43,7 +44,7 @@ function NumeroEditor({initialVoie, initialToponyme, initialValue, onSubmit, onC
     const body = {
       numero: Number(numero),
       voie: voie._id || null,
-      toponyme: initialToponyme ? initialToponyme._id : null,
+      toponyme: toponyme ? toponyme._id : null,
       suffixe: suffixe.length > 0 ? suffixe.toLowerCase().trim() : null,
       comment: comment.length > 0 ? comment : null
     }
@@ -72,7 +73,7 @@ function NumeroEditor({initialVoie, initialToponyme, initialValue, onSubmit, onC
       setError(error.message)
       setIsLoading(false)
     }
-  }, [numero, voie, initialToponyme, suffixe, comment, markers, onSubmit, disableMarkers])
+  }, [numero, voie, toponyme, suffixe, comment, markers, onSubmit, disableMarkers])
 
   const onFormCancel = useCallback(e => {
     e.preventDefault()
@@ -89,11 +90,17 @@ function NumeroEditor({initialVoie, initialToponyme, initialValue, onSubmit, onC
     return 'Enregistrer'
   }, [isLoading])
 
-  const handleVoieChange = event => {
+  const handleChange = event => {
     const {value} = event.target
     const voie = voies.find(({_id}) => _id === value)
 
     setVoie(voie)
+  }
+
+  const handleToponymeChange = e => {
+    const {value} = e.target
+
+    setToponyme(toponymes.find(({_id}) => _id === value))
   }
 
   useKeyEvent('keyup', ({key}) => {
@@ -139,7 +146,7 @@ function NumeroEditor({initialVoie, initialToponyme, initialValue, onSubmit, onC
           label='Voie'
           flex={1}
           marginBottom={16}
-          onChange={handleVoieChange}
+          onChange={handleChange}
         >
           <option />
           {sortBy(voies, v => normalizeSort(v.nom)).map(({_id, nom}) => (
@@ -159,7 +166,7 @@ function NumeroEditor({initialVoie, initialToponyme, initialValue, onSubmit, onC
           label='Toponyme'
           flex={1}
           marginBottom={16}
-          onChange={handleVoieChange}
+          onChange={handleToponymeChange}
         >
           <option />
           {sortBy(toponymes, t => normalizeSort(t.nom)).map(({_id, nom}) => (

--- a/components/bal/position-editor.js
+++ b/components/bal/position-editor.js
@@ -24,44 +24,50 @@ function PositionEditor({isToponyme}) {
 
   return (
     <>
-      <Pane display='grid' gridTemplateColumns='2fr .5fr 1fr 1fr .5fr'>
-        <Strong fontWeight={400}>Type</Strong>
-        <div />
-        <Strong fontWeight={400}>Latitude</Strong>
-        <Strong fontWeight={400}>Longitude</Strong>
-        <div />
+      {markers.length > 0 ? (
+        <Pane display='grid' gridTemplateColumns='2fr .5fr 1fr 1fr .5fr'>
+          <Strong fontWeight={400}>Type</Strong>
+          <div />
+          <Strong fontWeight={400}>Latitude</Strong>
+          <Strong fontWeight={400}>Longitude</Strong>
+          <div />
 
-        {markers.map(marker => (
-          <>
-            <SelectField
-              defaultValue={marker.type}
-              marginBottom={8}
-              height={32}
-              onChange={e => handleChange(e, marker)}
-            >
-              {positionsTypesList.map(positionType => (
-                <option key={positionType.value} value={positionType.value} selected={marker.type === positionType.value}>{positionType.name}</option>
-              ))}
-            </SelectField>
-            <Icon icon={MapMarkerIcon} size={22} margin='auto' />
-            <Heading size={100} marginY='auto'>
-              <Small>{marker.latitude && marker.latitude.toFixed(6)}</Small>
-            </Heading>
-            <Heading size={100} marginY='auto'>
-              <Small>{marker.longitude && marker.longitude.toFixed(6)}</Small>
-            </Heading>
-            <IconButton
-              disabled={markers.length === 1}
-              appearance='default'
-              iconSize={15}
-              icon={TrashIcon}
-              intent='danger'
-              onClick={e => deletePosition(e, marker)}
-            />
-          </>
-        ))}
+          {markers.map(marker => (
+            <>
+              <SelectField
+                defaultValue={marker.type}
+                marginBottom={8}
+                height={32}
+                onChange={e => handleChange(e, marker)}
+              >
+                {positionsTypesList.map(positionType => (
+                  <option key={positionType.value} value={positionType.value} selected={marker.type === positionType.value}>{positionType.name}</option>
+                ))}
+              </SelectField>
+              <Icon icon={MapMarkerIcon} size={22} margin='auto' />
+              <Heading size={100} marginY='auto'>
+                <Small>{marker.latitude && marker.latitude.toFixed(6)}</Small>
+              </Heading>
+              <Heading size={100} marginY='auto'>
+                <Small>{marker.longitude && marker.longitude.toFixed(6)}</Small>
+              </Heading>
+              <IconButton
+                disabled={isToponyme ? false : markers.length === 1}
+                appearance='default'
+                iconSize={15}
+                icon={TrashIcon}
+                intent='danger'
+                onClick={e => deletePosition(e, marker)}
+              />
+            </>
+          ))}
+        </Pane>
+      ) : (
+        <Pane paddingBottom='.5em' textAlign='center'>
+          <Heading size={400}>Ce toponyme n’a pas de position</Heading>
+        </Pane>
+      )}
 
-      </Pane>
       <Button
         type='button'
         iconBefore={AddIcon}

--- a/components/bal/toponyme-editor.js
+++ b/components/bal/toponyme-editor.js
@@ -45,19 +45,11 @@ function ToponymeEditor({initialValue, onSubmit, onCancel}) {
     try {
       await onSubmit(body)
       disableMarkers()
-
-      if (body.positions.length > 0) {
-        const {balId, codeCommune} = router.query
-        router.push(
-          `/bal/commune?balId=${balId}&codeCommune=${codeCommune}`,
-          `/bal/${balId}/communes/${codeCommune}`
-        )
-      }
     } catch (error) {
       setIsLoading(false)
       setError(error.message)
     }
-  }, [router, nom, markers, onSubmit, disableMarkers])
+  }, [nom, markers, onSubmit, disableMarkers])
 
   const onFormCancel = useCallback(e => {
     e.preventDefault()

--- a/components/bal/toponyme-editor.js
+++ b/components/bal/toponyme-editor.js
@@ -28,9 +28,6 @@ function ToponymeEditor({initialValue, onSubmit, onCancel}) {
 
     const body = {
       nom,
-      typeNumerotation: 'numerique',
-      complement: null,
-      trace: null,
       positions: []
     }
 
@@ -88,22 +85,20 @@ function ToponymeEditor({initialValue, onSubmit, onCancel}) {
   }, [onCancel])
 
   useEffect(() => {
-    if (markers.length === 0) {
-      if (initialValue && initialValue.positions.length > 0) {
-        const positions = initialValue.positions.map(position => (
-          {
-            longitude: position.point.coordinates[0],
-            latitude: position.point.coordinates[1],
-            type: position.type
-          }
-        ))
+    if (initialValue) {
+      const positions = initialValue.positions.map(position => (
+        {
+          longitude: position.point.coordinates[0],
+          latitude: position.point.coordinates[1],
+          type: position.type
+        }
+      ))
 
-        positions.forEach(position => addMarker(position))
-      } else {
-        addMarker({type: 'segment'})
-      }
+      positions.forEach(position => addMarker(position))
+    } else {
+      addMarker({type: 'segment'})
     }
-  }, [initialValue, markers, addMarker, disableMarkers])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <Pane is='form' onSubmit={onFormSubmit}>

--- a/components/bal/toponyme-editor.js
+++ b/components/bal/toponyme-editor.js
@@ -1,6 +1,5 @@
 import React, {useState, useMemo, useContext, useCallback, useEffect} from 'react'
 import PropTypes from 'prop-types'
-import {useRouter} from 'next/router'
 import {Pane, Button, Alert, TextInputField} from 'evergreen-ui'
 
 import MarkersContext from '../../contexts/markers'
@@ -12,8 +11,6 @@ import useKeyEvent from '../../hooks/key-event'
 import PositionEditor from './position-editor'
 
 function ToponymeEditor({initialValue, onSubmit, onCancel}) {
-  const router = useRouter()
-
   const [isLoading, setIsLoading] = useState(false)
   const [nom, onNomChange] = useInput(initialValue ? initialValue.nom : '')
   const [error, setError] = useState()

--- a/components/bal/toponyme-editor.js
+++ b/components/bal/toponyme-editor.js
@@ -145,7 +145,6 @@ function ToponymeEditor({initialValue, onSubmit, onCancel}) {
 ToponymeEditor.propTypes = {
   initialValue: PropTypes.shape({
     nom: PropTypes.string,
-    complement: PropTypes.string,
     typeNumerotation: PropTypes.string,
     trace: PropTypes.object,
     positions: PropTypes.array.isRequired

--- a/components/bal/toponymes-list.js
+++ b/components/bal/toponymes-list.js
@@ -14,7 +14,6 @@ import ToponymeEditor from './toponyme-editor'
 
 const ToponymesList = ({isAdding, onAdd, onEdit, onCancel, onSelect, onEnableEditing, isPopulating, setToRemove}) => {
   const {
-    baseLocale,
     isEditing,
     editingId,
     toponymes
@@ -39,7 +38,6 @@ const ToponymesList = ({isAdding, onAdd, onEdit, onCancel, onSelect, onEnableEdi
           <Table.Row height='auto'>
             <Table.Cell borderBottom display='block' paddingY={12} background='tint1'>
               <ToponymeEditor
-                isEnabledComplement={Boolean(baseLocale.enableComplement)}
                 onSubmit={onAdd}
                 onCancel={onCancel}
               />

--- a/components/bal/toponymes-list.js
+++ b/components/bal/toponymes-list.js
@@ -1,0 +1,98 @@
+import React, {useContext} from 'react'
+import PropTypes from 'prop-types'
+import {sortBy} from 'lodash'
+
+import {Pane, Table} from 'evergreen-ui'
+
+import BalDataContext from '../../contexts/bal-data'
+
+import useFuse from '../../hooks/fuse'
+
+import {normalizeSort} from '../../lib/normalize'
+import TableRow from '../table-row'
+import ToponymeEditor from './toponyme-editor'
+
+const ToponymesList = ({isAdding, onAdd, onEdit, onCancel, onSelect, onEnableEditing, isPopulating, setToRemove}) => {
+  const {
+    baseLocale,
+    isEditing,
+    editingId,
+    toponymes
+  } = useContext(BalDataContext)
+
+  const [filtered, setFilter] = useFuse(toponymes, 200, {
+    keys: [
+      'nom'
+    ]
+  })
+
+  return (
+    <Pane flex={1} overflowY='scroll'>
+      <Table>
+        <Table.Head>
+          <Table.SearchHeaderCell
+            placeholder='Rechercher un toponyme'
+            onChange={setFilter}
+          />
+        </Table.Head>
+        {isAdding && (
+          <Table.Row height='auto'>
+            <Table.Cell borderBottom display='block' paddingY={12} background='tint1'>
+              <ToponymeEditor
+                isEnabledComplement={Boolean(baseLocale.enableComplement)}
+                onSubmit={onAdd}
+                onCancel={onCancel}
+              />
+            </Table.Cell>
+          </Table.Row>
+        )}
+        {filtered.length === 0 && (
+          <Table.Row>
+            <Table.TextCell color='muted' fontStyle='italic'>
+              Aucun résultat
+            </Table.TextCell>
+          </Table.Row>
+        )}
+        {sortBy(filtered, t => normalizeSort(t.nom))
+          .map(toponyme => toponyme._id === editingId ? (
+            <Table.Row key={toponyme._id} height='auto'>
+              <Table.Cell display='block' paddingY={12} background='tint1'>
+                <ToponymeEditor
+                  initialValue={toponyme}
+                  onSubmit={onEdit}
+                  onCancel={onCancel}
+                />
+              </Table.Cell>
+            </Table.Row>
+          ) : (
+            <TableRow
+              key={toponyme._id}
+              id={toponyme._id}
+              isSelectable={!isEditing && !isPopulating}
+              label={toponyme.nom}
+              onSelect={onSelect}
+              onEdit={onEnableEditing}
+              onRemove={id => setToRemove(id)}
+            />
+          ))}
+      </Table>
+    </Pane>
+  )
+}
+
+ToponymesList.propTypes = {
+  isPopulating: PropTypes.bool,
+  isAdding: PropTypes.func.isRequired,
+  setToRemove: PropTypes.func.isRequired,
+  onEnableEditing: PropTypes.func.isRequired,
+  onSelect: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  onAdd: PropTypes.func.isRequired,
+  onEdit: PropTypes.func.isRequired
+}
+
+ToponymesList.defaultProps = {
+  isPopulating: false
+}
+
+export default ToponymesList

--- a/components/bal/toponymes-list.js
+++ b/components/bal/toponymes-list.js
@@ -66,6 +66,7 @@ const ToponymesList = ({isAdding, onAdd, onEdit, onCancel, onSelect, onEnableEdi
             <TableRow
               key={toponyme._id}
               id={toponyme._id}
+              warning={toponyme.positions.length === 0 ? 'Ce toponyme n’a pas de position' : null}
               isSelectable={!isEditing && !isPopulating}
               label={toponyme.nom}
               onSelect={onSelect}

--- a/components/bal/voie-editor.js
+++ b/components/bal/voie-editor.js
@@ -30,20 +30,17 @@ function VoieEditor({initialValue, onSubmit, onCancel}) {
     const body = {
       nom,
       typeNumerotation: isMetric ? 'metrique' : 'numerique',
-      trace: data ? data.geometry : null,
-      positions: []
+      trace: data ? data.geometry : null
     }
 
     try {
       await onSubmit(body)
 
-      if (body.positions.length > 0) {
-        const {balId, codeCommune} = router.query
-        router.push(
-          `/bal/commune?balId=${balId}&codeCommune=${codeCommune}`,
-          `/bal/${balId}/communes/${codeCommune}`
-        )
-      }
+      const {balId, codeCommune} = router.query
+      router.push(
+        `/bal/commune?balId=${balId}&codeCommune=${codeCommune}`,
+        `/bal/${balId}/communes/${codeCommune}`
+      )
     } catch (error) {
       setIsLoading(false)
       setError(error.message)
@@ -141,8 +138,7 @@ VoieEditor.propTypes = {
   initialValue: PropTypes.shape({
     nom: PropTypes.string,
     typeNumerotation: PropTypes.string,
-    trace: PropTypes.object,
-    positions: PropTypes.array.isRequired
+    trace: PropTypes.object
   }),
   onSubmit: PropTypes.func.isRequired,
   onCancel: PropTypes.func

--- a/components/bal/voie-editor.js
+++ b/components/bal/voie-editor.js
@@ -13,14 +13,13 @@ import useKeyEvent from '../../hooks/key-event'
 
 import DrawEditor from './draw-editor'
 
-function VoieEditor({initialValue, onSubmit, onCancel, isEnabledComplement}) {
+function VoieEditor({initialValue, onSubmit, onCancel}) {
   const router = useRouter()
 
   const [isLoading, setIsLoading] = useState(false)
   const [isToponyme, onIsToponymeChange] = useCheckboxInput(checkIsToponyme(initialValue))
   const [isMetric, onIsMetricChange] = useCheckboxInput(initialValue ? initialValue.typeNumerotation === 'metrique' : false)
   const [nom, onNomChange] = useInput(initialValue ? initialValue.nom : '')
-  const [complement, onComplementChange] = useInput(initialValue ? initialValue.complement : '')
   const [error, setError] = useState()
   const setRef = useFocus()
 
@@ -34,7 +33,6 @@ function VoieEditor({initialValue, onSubmit, onCancel, isEnabledComplement}) {
     const body = {
       nom,
       typeNumerotation: isMetric ? 'metrique' : 'numerique',
-      complement: complement.length > 1 ? complement : null,
       trace: data ? data.geometry : null,
       positions: []
     }
@@ -53,7 +51,7 @@ function VoieEditor({initialValue, onSubmit, onCancel, isEnabledComplement}) {
       setIsLoading(false)
       setError(error.message)
     }
-  }, [router, nom, isMetric, complement, data, onSubmit])
+  }, [router, nom, isMetric, data, onSubmit])
 
   const onFormCancel = useCallback(e => {
     e.preventDefault()
@@ -106,20 +104,6 @@ function VoieEditor({initialValue, onSubmit, onCancel, isEnabledComplement}) {
         placeholder={isToponyme ? 'Nom du toponyme…' : 'Nom de la voie…'}
         onChange={onNomChange}
       />
-      {isEnabledComplement && (
-        <TextInputField
-          display='block'
-          disabled={isLoading}
-          width='100%'
-          maxWidth={500}
-          label='Complément d’adresse'
-          value={complement}
-          maxLength={200}
-          marginBottom={16}
-          placeholder='Complément du nom de voie (lieu-dit, hameau, …)'
-          onChange={onComplementChange}
-        />
-      )}
 
       <Checkbox
         checked={isMetric}
@@ -159,20 +143,17 @@ function VoieEditor({initialValue, onSubmit, onCancel, isEnabledComplement}) {
 VoieEditor.propTypes = {
   initialValue: PropTypes.shape({
     nom: PropTypes.string,
-    complement: PropTypes.string,
     typeNumerotation: PropTypes.string,
     trace: PropTypes.object,
     positions: PropTypes.array.isRequired
   }),
   onSubmit: PropTypes.func.isRequired,
-  onCancel: PropTypes.func,
-  isEnabledComplement: PropTypes.bool
+  onCancel: PropTypes.func
 }
 
 VoieEditor.defaultProps = {
   initialValue: null,
-  onCancel: null,
-  isEnabledComplement: false
+  onCancel: null
 }
 
 export default VoieEditor

--- a/components/bal/voie-editor.js
+++ b/components/bal/voie-editor.js
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types'
 import {useRouter} from 'next/router'
 import {Pane, Button, Checkbox, Alert, TextInputField} from 'evergreen-ui'
 
-import {checkIsToponyme} from '../../lib/voie'
-
 import DrawContext from '../../contexts/draw'
 
 import {useInput, useCheckboxInput} from '../../hooks/input'
@@ -17,7 +15,6 @@ function VoieEditor({initialValue, onSubmit, onCancel}) {
   const router = useRouter()
 
   const [isLoading, setIsLoading] = useState(false)
-  const [isToponyme, onIsToponymeChange] = useCheckboxInput(checkIsToponyme(initialValue))
   const [isMetric, onIsMetricChange] = useCheckboxInput(initialValue ? initialValue.typeNumerotation === 'metrique' : false)
   const [nom, onNomChange] = useInput(initialValue ? initialValue.nom : '')
   const [error, setError] = useState()
@@ -80,7 +77,7 @@ function VoieEditor({initialValue, onSubmit, onCancel}) {
     } else if (!isMetric && drawEnabled) {
       disableDraw()
     }
-  }, [data, disableDraw, drawEnabled, enableDraw, isMetric, onIsToponymeChange, setModeId])
+  }, [data, disableDraw, drawEnabled, enableDraw, isMetric, setModeId])
 
   useEffect(() => {
     return () => {
@@ -101,7 +98,7 @@ function VoieEditor({initialValue, onSubmit, onCancel}) {
         value={nom}
         maxLength={200}
         marginBottom={16}
-        placeholder={isToponyme ? 'Nom du toponyme…' : 'Nom de la voie…'}
+        placeholder='Nom de la voie…'
         onChange={onNomChange}
       />
 

--- a/components/bal/voies-list.js
+++ b/components/bal/voies-list.js
@@ -1,0 +1,104 @@
+import React, {useContext} from 'react'
+import PropTypes from 'prop-types'
+import {sortBy} from 'lodash'
+
+import {Pane, Table} from 'evergreen-ui'
+
+import BalDataContext from '../../contexts/bal-data'
+
+import useFuse from '../../hooks/fuse'
+
+import {normalizeSort} from '../../lib/normalize'
+import {getFullVoieName} from '../../lib/voie'
+import TableRow from '../table-row'
+import VoieEditor from './voie-editor'
+
+const VoiesList = ({defaultVoies, onEnableEditing, isAdding, onSelect, isPopulating, onAdd, onEdit, onCancel, setToRemove}) => {
+  const {
+    baseLocale,
+    isEditing,
+    editingId,
+    voies
+  } = useContext(BalDataContext)
+
+  const [filtered, setFilter] = useFuse(voies || defaultVoies, 200, {
+    keys: [
+      'nom'
+    ]
+  })
+
+  return (
+    <Pane flex={1} overflowY='scroll'>
+      <Table>
+        <Table.Head>
+          <Table.SearchHeaderCell
+            placeholder='Rechercher une voie'
+            onChange={setFilter}
+          />
+        </Table.Head>
+        {isAdding && (
+          <Table.Row height='auto'>
+            <Table.Cell borderBottom display='block' paddingY={12} background='tint1'>
+              <VoieEditor
+                isEnabledComplement={Boolean(baseLocale.enableComplement)}
+                onSubmit={onAdd}
+                onCancel={onCancel}
+              />
+            </Table.Cell>
+          </Table.Row>
+        )}
+        {filtered.length === 0 && (
+          <Table.Row>
+            <Table.TextCell color='muted' fontStyle='italic'>
+              Aucun résultat
+            </Table.TextCell>
+          </Table.Row>
+        )}
+        {sortBy(filtered, v => normalizeSort(v.nom))
+          .map(voie => voie._id === editingId ? (
+            <Table.Row key={voie._id} height='auto'>
+              <Table.Cell display='block' paddingY={12} background='tint1'>
+                <VoieEditor
+                  isEnabledComplement={Boolean(baseLocale.enableComplement)}
+                  initialValue={voie}
+                  onSubmit={onEdit}
+                  onCancel={onCancel}
+                />
+              </Table.Cell>
+            </Table.Row>
+          ) : (
+            voie.positions.length === 0 && (
+              <TableRow
+                key={voie._id}
+                id={voie._id}
+                isSelectable={!isEditing && !isPopulating && voie.positions.length === 0}
+                label={getFullVoieName(voie, baseLocale.enableComplement)}
+                secondary={voie.positions.length >= 1 ? 'Toponyme' : null}
+                onSelect={onSelect}
+                onEdit={onEnableEditing}
+                onRemove={id => setToRemove(id)}
+              />)
+          ))}
+      </Table>
+    </Pane>
+  )
+}
+
+VoiesList.propTypes = {
+  defaultVoies: PropTypes.array,
+  isPopulating: PropTypes.bool,
+  isAdding: PropTypes.func.isRequired,
+  setToRemove: PropTypes.func.isRequired,
+  onEnableEditing: PropTypes.func.isRequired,
+  onSelect: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  onAdd: PropTypes.func.isRequired,
+  onEdit: PropTypes.func.isRequired
+}
+
+VoiesList.defaultProps = {
+  defaultVoies: null,
+  isPopulating: false
+}
+
+export default VoiesList

--- a/components/bal/voies-list.js
+++ b/components/bal/voies-list.js
@@ -9,13 +9,11 @@ import BalDataContext from '../../contexts/bal-data'
 import useFuse from '../../hooks/fuse'
 
 import {normalizeSort} from '../../lib/normalize'
-import {getFullVoieName} from '../../lib/voie'
 import TableRow from '../table-row'
 import VoieEditor from './voie-editor'
 
 const VoiesList = ({defaultVoies, onEnableEditing, isAdding, onSelect, isPopulating, onAdd, onEdit, onCancel, setToRemove}) => {
   const {
-    baseLocale,
     isEditing,
     editingId,
     voies
@@ -40,7 +38,6 @@ const VoiesList = ({defaultVoies, onEnableEditing, isAdding, onSelect, isPopulat
           <Table.Row height='auto'>
             <Table.Cell borderBottom display='block' paddingY={12} background='tint1'>
               <VoieEditor
-                isEnabledComplement={Boolean(baseLocale.enableComplement)}
                 onSubmit={onAdd}
                 onCancel={onCancel}
               />
@@ -59,7 +56,6 @@ const VoiesList = ({defaultVoies, onEnableEditing, isAdding, onSelect, isPopulat
             <Table.Row key={voie._id} height='auto'>
               <Table.Cell display='block' paddingY={12} background='tint1'>
                 <VoieEditor
-                  isEnabledComplement={Boolean(baseLocale.enableComplement)}
                   initialValue={voie}
                   onSubmit={onEdit}
                   onCancel={onCancel}
@@ -72,7 +68,7 @@ const VoiesList = ({defaultVoies, onEnableEditing, isAdding, onSelect, isPopulat
                 key={voie._id}
                 id={voie._id}
                 isSelectable={!isEditing && !isPopulating && voie.positions.length === 0}
-                label={getFullVoieName(voie, baseLocale.enableComplement)}
+                label={voie.nom}
                 onSelect={onSelect}
                 onEdit={onEnableEditing}
                 onRemove={id => setToRemove(id)}

--- a/components/bal/voies-list.js
+++ b/components/bal/voies-list.js
@@ -73,7 +73,6 @@ const VoiesList = ({defaultVoies, onEnableEditing, isAdding, onSelect, isPopulat
                 id={voie._id}
                 isSelectable={!isEditing && !isPopulating && voie.positions.length === 0}
                 label={getFullVoieName(voie, baseLocale.enableComplement)}
-                secondary={voie.positions.length >= 1 ? 'Toponyme' : null}
                 onSelect={onSelect}
                 onEdit={onEnableEditing}
                 onRemove={id => setToRemove(id)}

--- a/components/bal/voies-list.js
+++ b/components/bal/voies-list.js
@@ -63,16 +63,15 @@ const VoiesList = ({defaultVoies, onEnableEditing, isAdding, onSelect, isPopulat
               </Table.Cell>
             </Table.Row>
           ) : (
-            voie.positions.length === 0 && (
-              <TableRow
-                key={voie._id}
-                id={voie._id}
-                isSelectable={!isEditing && !isPopulating && voie.positions.length === 0}
-                label={voie.nom}
-                onSelect={onSelect}
-                onEdit={onEnableEditing}
-                onRemove={id => setToRemove(id)}
-              />)
+            <TableRow
+              key={voie._id}
+              id={voie._id}
+              isSelectable={!isEditing && !isPopulating}
+              label={voie.nom}
+              onSelect={onSelect}
+              onEdit={onEnableEditing}
+              onRemove={id => setToRemove(id)}
+            />
           ))}
       </Table>
     </Pane>

--- a/components/breadcrumbs.js
+++ b/components/breadcrumbs.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import NextLink from 'next/link'
 import {Pane, Link, Text} from 'evergreen-ui'
 
-function Breadcrumbs({baseLocale, commune, voie, ...props}) {
+function Breadcrumbs({baseLocale, commune, voie, toponyme, ...props}) {
   if (!commune) {
     return (
       <Pane paddingY={2} whiteSpace='nowrap' overflow='hidden' textOverflow='ellipsis' {...props}>
@@ -16,7 +16,7 @@ function Breadcrumbs({baseLocale, commune, voie, ...props}) {
     )
   }
 
-  if (!voie) {
+  if (!voie && !toponyme) {
     return (
       <Pane paddingY={2} whiteSpace='nowrap' overflow='hidden' textOverflow='ellipsis' {...props}>
         <NextLink prefetch href={`/bal?balId=${baseLocale._id}`} as={`/bal/${baseLocale._id}`}>
@@ -57,7 +57,7 @@ function Breadcrumbs({baseLocale, commune, voie, ...props}) {
       </NextLink>
 
       <Text color='muted'>{' > '}</Text>
-      <Text>{voie.nom}</Text>
+      <Text>{voie?.nom || toponyme.nom}</Text>
     </Pane>
   )
 }
@@ -73,12 +73,16 @@ Breadcrumbs.propTypes = {
   }),
   voie: PropTypes.shape({
     nom: PropTypes.string.isRequired
+  }),
+  toponyme: PropTypes.shape({
+    nom: PropTypes.string.isRequired
   })
 }
 
 Breadcrumbs.defaultProps = {
   commune: null,
-  voie: null
+  voie: null,
+  toponyme: null
 }
 
 export default React.memo(Breadcrumbs)

--- a/components/delete-warning.js
+++ b/components/delete-warning.js
@@ -10,7 +10,7 @@ function DeleteWarning({isShown, content, onCancel, onConfirm}) {
           isShown={isShown}
           title='Attention'
           intent='danger'
-          cancelLabelstring='Annuler'
+          cancelLabel='Annuler'
           confirmLabel='Supprimer'
           onCloseComplete={onCancel}
           onCancel={onCancel}

--- a/components/grouped-actions.js
+++ b/components/grouped-actions.js
@@ -26,6 +26,7 @@ const GroupedActions = ({idVoie, numeros, selectedNumerosIds, resetSelectedNumer
   const selectedNumerosUniqType = uniq(selectedNumeros.map(numero => (numero.positions[0].type)))
   const hasMultiposition = selectedNumeros.find(numero => numero.positions.length > 1)
   const selectedNumerosUniqToponyme = uniq(selectedNumeros.map(numero => numero.toponyme))
+  const hasUniqToponyme = selectedNumerosUniqToponyme.filter(Boolean).length === 1
   const selectedNumerosUniqVoie = uniq(selectedNumeros.map(numero => numero.voie))
 
   const handleComplete = () => {
@@ -131,9 +132,9 @@ const GroupedActions = ({idVoie, numeros, selectedNumerosIds, resetSelectedNumer
               flex={1}
               disabled={selectedNumerosUniqToponyme.length > 1}
               marginBottom={16}
-              onChange={event => setSelectedToponymeId(event.target.value)}
+              onChange={event => setSelectedToponymeId(event.target.value === '' ? null : event.target.value)}
             >
-              <option value={null}>- Choisir un toponyme -</option>
+              <option value=''>{selectedToponymeId || hasUniqToponyme ? 'Ne pas associer de toponyme' : '- Choisir un toponyme -'}</option>
               {sortBy(toponymes, t => normalizeSort(t.nom)).map(({_id, nom}) => (
                 <option
                   key={_id}

--- a/components/grouped-actions.js
+++ b/components/grouped-actions.js
@@ -133,7 +133,7 @@ const GroupedActions = ({idVoie, numeros, selectedNumerosIds, resetSelectedNumer
               marginBottom={16}
               onChange={event => setSelectedToponymeId(event.target.value)}
             >
-              <option value={null}>Pas de Toponyme</option>
+              <option value={null}>- Choisir un toponyme -</option>
               {sortBy(toponymes, t => normalizeSort(t.nom)).map(({_id, nom}) => (
                 <option
                   key={_id}

--- a/components/grouped-actions.js
+++ b/components/grouped-actions.js
@@ -133,7 +133,7 @@ const GroupedActions = ({idVoie, numeros, selectedNumerosIds, resetSelectedNumer
               marginBottom={16}
               onChange={event => setSelectedToponymeId(event.target.value)}
             >
-              <option />
+              <option value={null}>Pas de Toponyme</option>
               {sortBy(toponymes, t => normalizeSort(t.nom)).map(({_id, nom}) => (
                 <option
                   key={_id}

--- a/components/help/help-tabs/base-locale.js
+++ b/components/help/help-tabs/base-locale.js
@@ -47,7 +47,6 @@ const BaseLocale = () => {
         <OrderedList margin={8}>
           <ListItem>Changer le nom de votre Base Adresse Locale</ListItem>
           <ListItem>Ajouter ou supprimer des collaborateurs</ListItem>
-          <ListItem>Activer ou désactiver la saisie du complément du nom de voie</ListItem>
         </OrderedList>
 
         <Paragraph marginTop='default'>

--- a/components/help/help-tabs/index.js
+++ b/components/help/help-tabs/index.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import BaseLocale from './base-locale'
 import Communes from './communes'
 import Voies from './voies'
+import Toponymes from './toponymes'
 import Numeros from './numeros'
 import Publication from './publication'
 
@@ -11,6 +12,7 @@ export const TABS = [
   'Base locale',
   'Communes',
   'Voies',
+  'Toponymes',
   'Numéros',
   'Publication'
 ]
@@ -24,8 +26,10 @@ const HelpTabs = ({tab}) => {
     case 2:
       return <Voies />
     case 3:
-      return <Numeros />
+      return <Toponymes />
     case 4:
+      return <Numeros />
+    case 5:
       return <Publication />
     default:
       return <BaseLocale />

--- a/components/help/help-tabs/toponymes.js
+++ b/components/help/help-tabs/toponymes.js
@@ -1,0 +1,105 @@
+import React from 'react'
+import {OrderedList, Pane, ListItem, Button, AddIcon, MapMarkerIcon, Menu, MoreIcon, Paragraph, Tab, Heading, Text, TrashIcon, Select} from 'evergreen-ui'
+
+import Tuto from '../tuto'
+import Unauthorized from '../tuto/unauthorized'
+
+import Sidebar from '../tuto/sidebar'
+import Problems from './problems'
+
+const before = (
+  <Paragraph marginTop='default'>
+    Affichez la liste des toponymes d’une commune en cliquant sur le nom de celle-ci en haut à gauche de votre écran
+  </Paragraph>
+)
+
+const Toponymes = () => {
+  return (
+    <>
+      <Pane>
+        <Tuto title='Ajouter un toponyme'>
+          {before}
+          <OrderedList margin={8}>
+            <ListItem>
+              Sélectionnez l‘onglet <Tab><Heading size={300}>Liste des Toponymes</Heading></Tab>, puis cliquez sur <Button iconBefore={AddIcon} marginX={4} appearance='primary' intent='success'>Ajouter un toponyme</Button>
+            </ListItem>
+            <ListItem>
+              Entrez le nom du toponyme dans le champs <Text color='muted'><i>Nom du toponyme...</i></Text>
+            </ListItem>
+            <ListItem>
+              Un <MapMarkerIcon color='info' /> est apparu sur la carte, vous pouvez le déplacer pour assigner une ou plusieurs positions à votre toponyme.<br />
+              Vous pouvez préciser le type de position avec le menu déroulant <Select><option>Segment</option></Select>
+              Si vous ne souhaitez pas définir de position pour le toponyme, cliquez simplement sur <TrashIcon marginX={6} color='danger' verticalAlign='middle' />
+            </ListItem>
+          </OrderedList>
+        </Tuto>
+
+        <Tuto title='Assigner un numéro à un toponyme'>
+          {before}
+          <OrderedList margin={8}>
+            <ListItem>
+              Cliquez sur le bouton
+              <Button iconBefore={AddIcon} marginX={4} appearance='primary' intent='success'>Ajouter un numéro</Button>
+            </ListItem>
+            <ListItem>
+              Sélectionnez le voie du numéro que vous souhaitez assigner
+            </ListItem>
+            <ListItem>
+              Un menu déroulant va s’afficher. Vous pouvez sélectionner un ou plusieurs numéros de la liste. Tous les numéros de la liste seront assigné au toponyme si aucuns numéro n’est sélectionné.
+            </ListItem>
+            <ListItem>
+              Pour terminer, cliquez sur le bouton <Button marginX={4} appearance='primary' intent='success'>Enregistrer</Button>
+            </ListItem>
+          </OrderedList>
+        </Tuto>
+
+        <Tuto title='Éditer un toponyme'>
+          {before}
+          <OrderedList margin={8}>
+            <ListItem>
+              Cliquez sur le nom du toponyme
+            </ListItem>
+            <ListItem>
+              Éditer le nom du toponyme
+            </ListItem>
+            <ListItem>
+              Vous pouvez également modifier la position du toponyme en déplaçant le <MapMarkerIcon icon={MapMarkerIcon} color='info' /> sur la carte
+            </ListItem>
+            <ListItem>
+              Vous pouvez ajouter des positions avec le bouton <Button iconBefore={AddIcon} marginX={4} appearance='primary' intent='success'>Ajouter une position au toponyme</Button>
+              ou en supprimer avec le bouton <TrashIcon marginX={6} color='danger' verticalAlign='middle' />
+            </ListItem>
+            <ListItem>
+              Pour terminer, cliquez sur <Button marginX={4} appearance='primary' intent='success'>Enregistrer</Button>
+            </ListItem>
+          </OrderedList>
+        </Tuto>
+
+        <Tuto title='Supprimer un toponyme'>
+          {before}
+          <OrderedList margin={8}>
+            <ListItem>
+              Cliquez sur le bouton <Button background='tint1' iconBefore={MoreIcon} appearance='minimal' /> se situant à droite du nom du toponyme
+            </ListItem>
+            <ListItem>
+              <Pane display='flex' alignItems='center'>
+                Dans le menu qui vient d’apparaître, choisissez
+                <Menu.Item background='tint1' marginLeft={8} icon={TrashIcon} intent='danger'>
+                  Supprimer…
+                </Menu.Item>
+              </Pane>
+            </ListItem>
+            <ListItem>Pour terminer, confirmez votre choix en cliquant sur <Button marginX={4} intent='danger' appearance='primary'>Supprimer</Button></ListItem>
+          </OrderedList>
+        </Tuto>
+
+        <Problems>
+          <Unauthorized title='Je n’arrive pas à ajouter/supprimer un toponyme' />
+          <Sidebar />
+        </Problems>
+      </Pane>
+    </>
+  )
+}
+
+export default Toponymes

--- a/components/help/help-tabs/voies.js
+++ b/components/help/help-tabs/voies.js
@@ -41,7 +41,7 @@ const Voies = () => {
             <ListItem>Cliquez sur le du nom de la voie</ListItem>
             <ListItem>Éditer le nom de la voie</ListItem>
             <ListItem>
-              Pour terminer, cliquez sur <Button marginX={4} appearance='primary' intent='success'>Modifier</Button>
+              Pour terminer, cliquez sur <Button marginX={4} appearance='primary' intent='success'>Enregistrer</Button>
             </ListItem>
           </OrderedList>
 

--- a/components/help/help-tabs/voies.js
+++ b/components/help/help-tabs/voies.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import {Pane, Paragraph, OrderedList, ListItem, Strong, Menu, Button, IconButton, MapMarkerIcon, AddIcon, ColumnLayoutIcon, MapIcon, MoreIcon, SendToMapIcon, TrashIcon} from 'evergreen-ui'
+import {Pane, Paragraph, OrderedList, ListItem, Strong, Menu, Button, AddIcon, ColumnLayoutIcon, MapIcon, MoreIcon, SendToMapIcon, TrashIcon} from 'evergreen-ui'
 
 import Tuto from '../tuto'
 import SubTuto from '../tuto/sub-tuto'

--- a/components/help/help-tabs/voies.js
+++ b/components/help/help-tabs/voies.js
@@ -34,53 +34,6 @@ const Voies = () => {
           </OrderedList>
         </Tuto>
 
-        <Tuto title='Ajouter un toponyme'>
-          <SubTuto title='Depuis le menu latéral' icon={ColumnLayoutIcon}>
-            {before}
-
-            <OrderedList margin={8}>
-              <ListItem>
-                Cliquez sur le bouton
-                <Button iconBefore={AddIcon} marginX={4} appearance='primary' intent='success'>Ajouter une voie</Button>
-              </ListItem>
-              <ListItem>
-                Cochez la case <Strong size={500} fontStyle='italic'>Cette voie est un toponyme</Strong>
-              </ListItem>
-              <ListItem>
-                Entrez le nom du toponyme que vous souhaitez créer dans le champ <Strong size={500} fontStyle='italic'>Nom du toponyme…</Strong>
-              </ListItem>
-              <ListItem>
-                Un <MapMarkerIcon color='info' /> est apparu au centre de la carte, déplacez le à l’endroit souhaité à l’aide de votre souris
-              </ListItem>
-              <ListItem>
-                Pour terminer, cliquez sur le bouton <Button marginX={4} appearance='primary' intent='success'>Ajouter</Button>
-              </ListItem>
-            </OrderedList>
-          </SubTuto>
-
-          <SubTuto title='Depuis la carte' icon={MapIcon}>
-            <OrderedList margin={8}>
-              <ListItem>
-                <Pane display='flex' alignItems='center'>
-                  Cliquez sur le bouton <IconButton marginLeft={8} icon={MapMarkerIcon} />
-                </Pane>
-              </ListItem>
-              <ListItem>
-                Un <MapMarkerIcon color='info' /> est apparu au centre de la carte, déplacez le à l’endroit souhaité à l’aide de votre souris
-              </ListItem>
-              <ListItem>
-                Dans le nouveau menu qui est apparu, cochez la case <Strong size={500} fontStyle='italic'>Cette voie est un toponyme</Strong>
-              </ListItem>
-              <ListItem>
-                Entrez le nom du toponyme que vous souhaitez créer dans le champ <Strong size={500} fontStyle='italic'>Nom du toponyme…</Strong>
-              </ListItem>
-              <ListItem>
-                Pour terminer, cliquez sur le bouton <Button marginX={4} appearance='primary' intent='success'>Ajouter</Button>
-              </ListItem>
-            </OrderedList>
-          </SubTuto>
-        </Tuto>
-
         <Tuto title='Renommer une voie'>
           {before}
 
@@ -137,22 +90,6 @@ const Voies = () => {
             </ListItem>
             <ListItem>Pour terminer, confirmez votre choix en cliquant sur <Button marginX={4} intent='danger' appearance='primary'>Supprimer</Button></ListItem>
           </OrderedList>
-        </Tuto>
-
-        <Tuto title='Supprimer un toponyme'>
-          <SubTuto title='Depuis la carte' icon={MapIcon}>
-            <OrderedList margin={8}>
-              <ListItem>Faites un clique droit sur le toponyme</ListItem>
-              <ListItem>
-                <Pane display='flex' alignItems='center'>
-                  Dans le menu qui vient d’apparaître, choisissez
-                  <Menu.Item background='tint1' marginLeft={8} icon={TrashIcon} intent='danger'>
-                    Supprimer…
-                  </Menu.Item>
-                </Pane>
-              </ListItem>
-            </OrderedList>
-          </SubTuto>
         </Tuto>
 
         <Problems>

--- a/components/map/hooks/bounds.js
+++ b/components/map/hooks/bounds.js
@@ -21,9 +21,16 @@ function useBounds(commune, voie, toponyme) {
       }
 
       if (toponyme) {
+        const numeroToponyme = data.features.filter(feature => feature.properties.idToponyme === toponyme._id)
         data = {
           type: 'FeatureCollection',
-          features: data.features.filter(feature => feature.properties.idToponyme === toponyme._id)
+          features: numeroToponyme.length === 0 && toponyme.positions.length === 1 ?
+            [{
+              type: 'Feature',
+              geometry: toponyme.positions[0].point,
+              properties: {id: toponyme._id}
+            }] :
+            numeroToponyme
         }
       }
 

--- a/components/map/hooks/bounds.js
+++ b/components/map/hooks/bounds.js
@@ -50,7 +50,7 @@ function useBounds(commune, voie, toponyme) {
     }
 
     return null
-  }, [commune, voie]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [commune, voie, toponyme]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return useMemo(() => data ? bbox(data) : data, [data])
 }

--- a/components/map/hooks/bounds.js
+++ b/components/map/hooks/bounds.js
@@ -6,7 +6,7 @@ import BalDataContext from '../../../contexts/bal-data'
 
 const BUFFER_RADIUS = 100
 
-function useBounds(commune, voie) {
+function useBounds(commune, voie, toponyme) {
   const {geojson} = useContext(BalDataContext)
 
   const data = useMemo(() => {
@@ -17,6 +17,13 @@ function useBounds(commune, voie) {
         data = {
           type: 'FeatureCollection',
           features: data.features.filter(feature => feature.properties.idVoie === voie._id)
+        }
+      }
+
+      if (toponyme) {
+        data = {
+          type: 'FeatureCollection',
+          features: data.features.filter(feature => feature.properties.idToponyme === toponyme._id)
         }
       }
 

--- a/components/map/hooks/layers.js
+++ b/components/map/hooks/layers.js
@@ -3,7 +3,7 @@ import {useMemo} from 'react'
 import {getVoiesLabelLayer, getVoieTraceLayer} from '../layers/voies'
 import {getNumerosPointLayer, getNumerosLabelLayer} from '../layers/numeros'
 
-function useLayers(voie, sources, style, isComplementEnabled) {
+function useLayers(voie, sources, style) {
   return useMemo(() => {
     const hasNumeros = sources.find(({name}) => name === 'positions')
     const hasVoies = sources.find(({name}) => name === 'voies')
@@ -21,12 +21,12 @@ function useLayers(voie, sources, style, isComplementEnabled) {
 
     if (!voie && hasVoies) {
       layers.push(
-        getVoiesLabelLayer(style, isComplementEnabled)
+        getVoiesLabelLayer(style)
       )
     }
 
     return layers
-  }, [voie, sources, style, isComplementEnabled])
+  }, [voie, sources, style])
 }
 
 export default useLayers

--- a/components/map/layers/voies.js
+++ b/components/map/layers/voies.js
@@ -1,4 +1,4 @@
-export function getVoiesLabelLayer(style, isComplementEnabled) {
+export function getVoiesLabelLayer(style) {
   const layer = {
     id: 'voie-label',
     interactive: true,
@@ -22,12 +22,7 @@ export function getVoiesLabelLayer(style, isComplementEnabled) {
       }
     },
     layout: {
-      'text-field': isComplementEnabled ? [
-        'case',
-        ['has', 'complement'],
-        ['concat', ['get', 'nomVoie'], '\n(', ['get', 'complement'], ')'],
-        ['get', 'nomVoie']
-      ] : ['get', 'nomVoie'],
+      'text-field': ['get', 'nomVoie'],
       'text-anchor': 'top',
       'text-size': {
         base: 1,

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -109,7 +109,7 @@ function Map({interactive, style: defaultStyle, commune, voie, toponyme}) {
 
   const sources = useSources(voie, hovered, editingId)
   const bounds = useBounds(commune, voie, toponyme)
-  const layers = useLayers(voie, sources, style, baseLocale.enableComplement)
+  const layers = useLayers(voie, sources, style)
 
   const mapRef = useCallback(ref => {
     if (ref) {

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -339,7 +339,7 @@ function Map({interactive, style: defaultStyle, commune, voie, toponyme}) {
             <NumeroMarker
               key={numero._id}
               numero={numero}
-              colorSeed={numero.voie}
+              colorSeed={voie._id}
               showLabel={showNumeros}
               showContextMenu={numero._id === showContextMenu}
               setShowContextMenu={setShowContextMenu}

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -349,7 +349,7 @@ function Map({interactive, style: defaultStyle, commune, voie}) {
           {toponymes && toponymes.map(toponyme => (
             <ToponymeMarker
               key={toponyme._id}
-              toponyme={toponyme}
+              initialToponyme={toponyme}
               showLabel={showNumeros}
               showContextMenu={toponyme._id === showContextMenu}
               setShowContextMenu={setShowContextMenu}

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -78,7 +78,7 @@ function generateNewStyle(style, sources, layers) {
   return baseStyle.updateIn(['layers'], arr => arr.push(...layers))
 }
 
-function Map({interactive, style: defaultStyle, commune, voie}) {
+function Map({interactive, style: defaultStyle, commune, voie, toponyme}) {
   const router = useRouter()
   const {viewport, setViewport} = useContext(MapContext)
 
@@ -108,7 +108,7 @@ function Map({interactive, style: defaultStyle, commune, voie}) {
   const {token} = useContext(TokenContext)
 
   const sources = useSources(voie, hovered, editingId)
-  const bounds = useBounds(commune, voie)
+  const bounds = useBounds(commune, voie, toponyme)
   const layers = useLayers(voie, sources, style, baseLocale.enableComplement)
 
   const mapRef = useCallback(ref => {
@@ -391,14 +391,16 @@ Map.propTypes = {
     'vector-cadastre'
   ]),
   commune: PropTypes.object,
-  voie: PropTypes.object
+  voie: PropTypes.object,
+  toponyme: PropTypes.object
 }
 
 Map.defaultProps = {
   interactive: true,
   style: 'vector',
   commune: null,
-  voie: null
+  voie: null,
+  toponyme: null
 }
 
 export default Map

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -10,7 +10,7 @@ import BalDataContext from '../../contexts/bal-data'
 import TokenContext from '../../contexts/token'
 import DrawContext from '../../contexts/draw'
 
-import {addNumero, addVoie} from '../../lib/bal-api'
+import {addNumero, addToponyme, addVoie} from '../../lib/bal-api'
 
 import AddressEditor from '../bal/address-editor'
 
@@ -201,6 +201,16 @@ function Map({interactive, style: defaultStyle, commune, voie}) {
     reloadView(editedVoie._id, Boolean(!voie), Boolean(numero))
   }, [baseLocale._id, commune, voie, token, reloadView])
 
+  const onAddToponyme = useCallback(async toponymeData => {
+    const editedToponyme = await addToponyme(baseLocale._id, commune.code, toponymeData, token)
+
+    setOpenForm(false)
+    router.push(
+      `/bal/toponyme?balId=${baseLocale._id}&codeCommune=${commune.code}&idToponyme=${editedToponyme._id}`,
+      `/bal/${baseLocale._id}/communes/${commune.code}/toponymes/${editedToponyme._id}`
+    )
+  }, [baseLocale._id, commune, token, router])
+
   useEffect(() => {
     if (sources.length > 0) {
       setMapStyle(generateNewStyle(style, sources, layers))
@@ -364,7 +374,7 @@ function Map({interactive, style: defaultStyle, commune, voie}) {
           <AddressEditor
             isToponyme={isToponyme}
             setIsToponyme={setIsToponyme}
-            onSubmit={onAddAddress}
+            onSubmit={isToponyme ? onAddToponyme : onAddAddress}
             onCancel={() => setOpenForm(false)}
           />
         </Pane>

--- a/components/map/numero-marker.js
+++ b/components/map/numero-marker.js
@@ -93,9 +93,8 @@ function NumeroMarker({numero, colorSeed, showLabel, showContextMenu, setShowCon
   return (
     <>
       <Marker longitude={coordinates[0]} latitude={coordinates[1]} captureDrag={false}>
-
         {numero.positions.find(position => position.type === 'inconnue') ? (
-          <Tooltip content='Le type de la position est inconnu' position={Position.RIGHT}>
+          <Tooltip content='Le type d’une position est inconnu' position={Position.RIGHT}>
             <Pane {...markerStyle} onClick={onEnableEditing} onContextMenu={() => setShowContextMenu(numero._id)}>
               <Text color='white' paddingLeft={8} paddingRight={5}>
                 {numero.numeroComplet}

--- a/components/map/toponyme-marker.js
+++ b/components/map/toponyme-marker.js
@@ -14,30 +14,30 @@ import TokenContext from '../../contexts/token'
 import MarkersContext from '../../contexts/markers'
 import BalDataContext from '../../contexts/bal-data'
 
-function ToponymeMarker({toponyme, showLabel, showContextMenu, setShowContextMenu}) {
+function ToponymeMarker({initialToponyme, showLabel, showContextMenu, setShowContextMenu}) {
   const [setError] = useError()
   const router = useRouter()
 
   const {token} = useContext(TokenContext)
   const {markers} = useContext(MarkersContext)
-  const {baseLocale, editingId, setEditingId, isEditing, reloadVoies, voie} = useContext(BalDataContext)
+  const {baseLocale, editingId, setEditingId, isEditing, reloadVoies, voie, toponyme} = useContext(BalDataContext)
 
   const onEnableEditing = useCallback(e => {
     e.stopPropagation()
 
-    if (voie) {
+    if (voie || initialToponyme !== toponyme) {
       router.push(
-        `/bal/toponyme?balId=${baseLocale._id}&codeCommune=${toponyme.commune}&idToponyme=${toponyme._id}`,
-        `/bal/${baseLocale._id}/communes/${toponyme.commune}/toponymes/${toponyme._id}`
+        `/bal/toponyme?balId=${baseLocale._id}&codeCommune=${initialToponyme.commune}&idToponyme=${initialToponyme._id}`,
+        `/bal/${baseLocale._id}/communes/${initialToponyme.commune}/toponymes/${initialToponyme._id}`
       )
     }
 
-    if (!isEditing && !voie) {
+    if (!isEditing && !voie && initialToponyme._id === toponyme?._id) {
       setEditingId(toponyme._id)
     }
-  }, [isEditing, toponyme._id, setEditingId, voie, baseLocale._id, toponyme.commune, router])
+  }, [isEditing, setEditingId, voie, baseLocale._id, initialToponyme, router, toponyme])
 
-  const position = toponyme.positions.find(position => position.type === 'segment') || toponyme.positions[0]
+  const position = initialToponyme.positions.find(position => position.type === 'segment') || initialToponyme.positions[0]
 
   const markerStyle = useMemo(() => css({
     borderRadius: 20,
@@ -54,7 +54,7 @@ function ToponymeMarker({toponyme, showLabel, showContextMenu, setShowContextMen
   }), [showLabel])
 
   const removeAddress = (async () => {
-    const {_id} = toponyme
+    const {_id} = initialToponyme
 
     try {
       await removeVoie(_id, token)
@@ -70,7 +70,7 @@ function ToponymeMarker({toponyme, showLabel, showContextMenu, setShowContextMen
     return null
   }
 
-  if (markers.length > 0 && editingId === toponyme._id) {
+  if (markers.length > 0 && editingId === initialToponyme._id) {
     return null
   }
 
@@ -79,9 +79,9 @@ function ToponymeMarker({toponyme, showLabel, showContextMenu, setShowContextMen
   return (
     <>
       <Marker longitude={coordinates[0]} latitude={coordinates[1]} captureDrag={false}>
-        <Pane {...markerStyle} onClick={onEnableEditing} onContextMenu={() => setShowContextMenu(toponyme._id)}>
+        <Pane {...markerStyle} onClick={onEnableEditing} onContextMenu={() => setShowContextMenu(initialToponyme._id)}>
           <Text color='white' paddingLeft={8} paddingRight={10}>
-            {getFullVoieName(toponyme, baseLocale.enableComplement)}
+            {getFullVoieName(initialToponyme, baseLocale.enableComplement)}
           </Text>
         </Pane>
 
@@ -102,7 +102,7 @@ function ToponymeMarker({toponyme, showLabel, showContextMenu, setShowContextMen
 }
 
 ToponymeMarker.propTypes = {
-  toponyme: PropTypes.shape({
+  initialToponyme: PropTypes.shape({
     _id: PropTypes.string.isRequired,
     positions: PropTypes.arrayOf(PropTypes.shape({
       point: PropTypes.shape({

--- a/components/map/toponyme-marker.js
+++ b/components/map/toponyme-marker.js
@@ -5,8 +5,7 @@ import {useRouter} from 'next/router'
 import {Pane, Text, Menu, TrashIcon} from 'evergreen-ui'
 import {css} from 'glamor'
 
-import {removeVoie} from '../../lib/bal-api'
-import {getFullVoieName} from '../../lib/voie'
+import {removeToponyme} from '../../lib/bal-api'
 
 import useError from '../../hooks/error'
 
@@ -20,7 +19,7 @@ function ToponymeMarker({initialToponyme, showLabel, showContextMenu, setShowCon
 
   const {token} = useContext(TokenContext)
   const {markers} = useContext(MarkersContext)
-  const {baseLocale, editingId, setEditingId, isEditing, reloadVoies, voie, toponyme} = useContext(BalDataContext)
+  const {baseLocale, editingId, setEditingId, isEditing, reloadToponymes, voie, toponyme} = useContext(BalDataContext)
 
   const onEnableEditing = useCallback(e => {
     e.stopPropagation()
@@ -53,12 +52,12 @@ function ToponymeMarker({initialToponyme, showLabel, showContextMenu, setShowCon
     }
   }), [showLabel])
 
-  const removeAddress = (async () => {
+  const deleteToponyme = (async () => {
     const {_id} = initialToponyme
 
     try {
-      await removeVoie(_id, token)
-      await reloadVoies()
+      await removeToponyme(_id, token)
+      await reloadToponymes()
     } catch (error) {
       setError(error.message)
     }
@@ -81,7 +80,7 @@ function ToponymeMarker({initialToponyme, showLabel, showContextMenu, setShowCon
       <Marker longitude={coordinates[0]} latitude={coordinates[1]} captureDrag={false}>
         <Pane {...markerStyle} onClick={onEnableEditing} onContextMenu={() => setShowContextMenu(initialToponyme._id)}>
           <Text color='white' paddingLeft={8} paddingRight={10}>
-            {getFullVoieName(initialToponyme, baseLocale.enableComplement)}
+            {initialToponyme.nom}
           </Text>
         </Pane>
 
@@ -89,7 +88,7 @@ function ToponymeMarker({initialToponyme, showLabel, showContextMenu, setShowCon
           <Pane background='tint1' position='absolute' margin={10}>
             <Menu>
               <Menu.Group>
-                <Menu.Item icon={TrashIcon} intent='danger' onSelect={removeAddress}>
+                <Menu.Item icon={TrashIcon} intent='danger' onSelect={deleteToponyme}>
                   Supprimer…
                 </Menu.Item>
               </Menu.Group>
@@ -104,6 +103,7 @@ function ToponymeMarker({initialToponyme, showLabel, showContextMenu, setShowCon
 ToponymeMarker.propTypes = {
   initialToponyme: PropTypes.shape({
     _id: PropTypes.string.isRequired,
+    nom: PropTypes.string.isRequired,
     positions: PropTypes.arrayOf(PropTypes.shape({
       point: PropTypes.shape({
         coordinates: PropTypes.arrayOf(PropTypes.number).isRequired

--- a/components/map/toponyme-marker.js
+++ b/components/map/toponyme-marker.js
@@ -58,6 +58,13 @@ function ToponymeMarker({initialToponyme, showLabel, showContextMenu, setShowCon
     try {
       await removeToponyme(_id, token)
       await reloadToponymes()
+
+      if (_id === toponyme._id) {
+        router.push(
+          `/bal/&codeCommune=${initialToponyme.commune}`,
+          `/bal/${baseLocale._id}/communes/${initialToponyme.commune}`
+        )
+      }
     } catch (error) {
       setError(error.message)
     }

--- a/components/map/toponyme-marker.js
+++ b/components/map/toponyme-marker.js
@@ -1,6 +1,7 @@
 import React, {useMemo, useCallback, useContext} from 'react'
 import PropTypes from 'prop-types'
 import {Marker} from 'react-map-gl'
+import {useRouter} from 'next/router'
 import {Pane, Text, Menu, TrashIcon} from 'evergreen-ui'
 import {css} from 'glamor'
 
@@ -15,18 +16,26 @@ import BalDataContext from '../../contexts/bal-data'
 
 function ToponymeMarker({toponyme, showLabel, showContextMenu, setShowContextMenu}) {
   const [setError] = useError()
+  const router = useRouter()
 
   const {token} = useContext(TokenContext)
   const {markers} = useContext(MarkersContext)
-  const {baseLocale, editingId, setEditingId, isEditing, reloadVoies} = useContext(BalDataContext)
+  const {baseLocale, editingId, setEditingId, isEditing, reloadVoies, voie} = useContext(BalDataContext)
 
   const onEnableEditing = useCallback(e => {
     e.stopPropagation()
 
-    if (!isEditing) {
+    if (voie) {
+      router.push(
+        `/bal/toponyme?balId=${baseLocale._id}&codeCommune=${toponyme.commune}&idToponyme=${toponyme._id}`,
+        `/bal/${baseLocale._id}/communes/${toponyme.commune}/toponymes/${toponyme._id}`
+      )
+    }
+
+    if (!isEditing && !voie) {
       setEditingId(toponyme._id)
     }
-  }, [isEditing, toponyme._id, setEditingId])
+  }, [isEditing, toponyme._id, setEditingId, voie, baseLocale._id, toponyme.commune, router])
 
   const position = toponyme.positions.find(position => position.type === 'segment') || toponyme.positions[0]
 
@@ -98,8 +107,9 @@ ToponymeMarker.propTypes = {
     positions: PropTypes.arrayOf(PropTypes.shape({
       point: PropTypes.shape({
         coordinates: PropTypes.arrayOf(PropTypes.number).isRequired
-      }).isRequired
-    }))
+      })
+    })),
+    commune: PropTypes.string
   }).isRequired,
   showLabel: PropTypes.bool,
   showContextMenu: PropTypes.bool,

--- a/components/settings.js
+++ b/components/settings.js
@@ -12,7 +12,6 @@ import {
   Spinner,
   Label,
   toaster,
-  Switch,
   DeleteIcon,
   AddIcon
 } from 'evergreen-ui'
@@ -22,7 +21,7 @@ import {updateBaseLocale} from '../lib/bal-api'
 
 import TokenContext from '../contexts/token'
 
-import {useInput, useCheckboxInput} from '../hooks/input'
+import {useInput} from '../hooks/input'
 import SettingsContext from '../contexts/settings'
 import {validateEmail} from '../lib/utils/email'
 import BalDataContext from '../contexts/bal-data'
@@ -33,7 +32,7 @@ const mailHasChanged = (listA, listB) => {
   return !isEqual([...listA].sort(), [...listB].sort())
 }
 
-const Settings = React.memo(({nomBaseLocale, isEnabledComplement}) => {
+const Settings = React.memo(({nomBaseLocale}) => {
   const {showSettings, setShowSettings} = useContext(SettingsContext)
   const {token, emails, reloadEmails} = useContext(TokenContext)
   const {baseLocale, reloadBaseLocale} = useContext(BalDataContext)
@@ -44,14 +43,12 @@ const Settings = React.memo(({nomBaseLocale, isEnabledComplement}) => {
   const [email, onEmailChange, resetEmail] = useInput()
   const [hasChanges, setHasChanges] = useState(false)
   const [error, setError] = useState()
-  const [enableComplement, onEnableComplement] = useCheckboxInput(Boolean(isEnabledComplement))
   const [isRenewTokenWarningShown, setIsRenewTokenWarningShown] = useState(false)
 
   const formHasChanged = useCallback(() => {
     return nomInput !== baseLocale.nom ||
-    mailHasChanged(emails || [], balEmails) ||
-    enableComplement !== Boolean(baseLocale.enableComplement)
-  }, [nomInput, baseLocale, emails, balEmails, enableComplement])
+    mailHasChanged(emails || [], balEmails)
+  }, [nomInput, baseLocale, emails, balEmails])
 
   useEffect(() => {
     setBalEmails(emails || [])
@@ -81,8 +78,7 @@ const Settings = React.memo(({nomBaseLocale, isEnabledComplement}) => {
     try {
       await updateBaseLocale(baseLocale._id, {
         nom: nomInput.trim(),
-        emails: balEmails,
-        enableComplement
+        emails: balEmails
       }, token)
 
       await reloadEmails()
@@ -98,7 +94,7 @@ const Settings = React.memo(({nomBaseLocale, isEnabledComplement}) => {
     }
 
     setIsLoading(false)
-  }, [baseLocale._id, nomInput, balEmails, token, reloadEmails, reloadBaseLocale, enableComplement, emails])
+  }, [baseLocale._id, nomInput, balEmails, token, reloadEmails, reloadBaseLocale, emails])
 
   useEffect(() => {
     if (error) {
@@ -220,17 +216,6 @@ const Settings = React.memo(({nomBaseLocale, isEnabledComplement}) => {
               />
             )}
 
-            <Label marginBottom={4} display='block'>
-              Activer la saisie du complément du nom de voie (lieu-dit, hameau, …)
-            </Label>
-            <Switch
-              height={20}
-              marginBottom={10}
-              disabled={baseLocale.status === 'demo'}
-              checked={enableComplement}
-              onChange={onEnableComplement}
-            />
-
             <Button height={40} marginTop={8} type='submit' appearance='primary' disabled={!hasChanges} isLoading={isLoading}>
               {isLoading ? 'En cours…' : 'Enregistrer les changements'}
             </Button>
@@ -262,8 +247,7 @@ const Settings = React.memo(({nomBaseLocale, isEnabledComplement}) => {
 })
 
 Settings.propTypes = {
-  nomBaseLocale: PropTypes.string.isRequired,
-  isEnabledComplement: PropTypes.bool.isRequired
+  nomBaseLocale: PropTypes.string.isRequired
 }
 
 export default Settings

--- a/components/sub-header/index.js
+++ b/components/sub-header/index.js
@@ -20,7 +20,7 @@ import DemoWarning from './demo-warning'
 
 const ADRESSE_URL = process.env.NEXT_PUBLIC_ADRESSE_URL || 'https://adresse.data.gouv.fr'
 
-const SubHeader = React.memo(({commune, voie, layout, isSidebarHidden, onToggle}) => {
+const SubHeader = React.memo(({commune, voie, toponyme, layout, isSidebarHidden, onToggle}) => {
   const {baseLocale, reloadBaseLocale} = useContext(BalDataContext)
   const {showHelp, setShowHelp} = useContext(HelpContext)
   const {showSettings, setShowSettings} = useContext(SettingsContext)
@@ -80,6 +80,7 @@ const SubHeader = React.memo(({commune, voie, layout, isSidebarHidden, onToggle}
           baseLocale={baseLocale}
           commune={commune}
           voie={voie}
+          toponyme={toponyme}
           marginLeft={8}
         />
 
@@ -150,6 +151,7 @@ const SubHeader = React.memo(({commune, voie, layout, isSidebarHidden, onToggle}
 SubHeader.propTypes = {
   commune: PropTypes.object,
   voie: PropTypes.object,
+  toponyme: PropTypes.object,
   layout: PropTypes.oneOf(['fullscreen', 'sidebar']).isRequired,
   isSidebarHidden: PropTypes.bool,
   onToggle: PropTypes.func.isRequired
@@ -158,6 +160,7 @@ SubHeader.propTypes = {
 SubHeader.defaultProps = {
   commune: null,
   voie: null,
+  toponyme: null,
   isSidebarHidden: false
 }
 

--- a/components/table-row.js
+++ b/components/table-row.js
@@ -71,7 +71,7 @@ const TableRow = React.memo(({id, code, positions, label, comment, secondary, is
           className='edit-cell'
         >
           {label} <i>{toponymeName && ` - ${toponymeName}`}</i>
-          {!isEditing && onEdit && (
+          {!isEditing && onEdit && token && (
             <span className='pencil-icon'>
               <EditIcon marginBottom={-4} marginLeft={8} />
             </span>

--- a/components/table-row.js
+++ b/components/table-row.js
@@ -8,8 +8,9 @@ import BalDataContext from '../contexts/bal-data'
 const TableRow = React.memo(({id, code, positions, label, comment, secondary, isSelectable, onSelect, onEdit, onRemove, handleSelect, isSelected}) => {
   const [hovered, setHovered] = useState(false)
   const {token} = useContext(TokenContext)
-  const {numeros, isEditing} = useContext(BalDataContext)
+  const {numeros, numerosToponyme, isEditing} = useContext(BalDataContext)
   const {type} = positions[0] || {}
+  const hasNumero = (numeros && numeros.length > 1) || (numerosToponyme && numerosToponyme.length > 1)
 
   const onClick = useCallback(e => {
     if (e.target.closest('[data-editable]') && !isEditing && !code) { // Not a commune
@@ -45,7 +46,7 @@ const TableRow = React.memo(({id, code, positions, label, comment, secondary, is
 
   return (
     <Table.Row isSelectable={isSelectable} style={{backgroundColor: hovered ? '#f5f6f7' : ''}} onClick={onClick}>
-      {token && !isEditing && numeros && numeros.length > 1 && (
+      {token && !isEditing && hasNumero && (
         <Table.Cell flex='0 1 1'>
           <Checkbox
             checked={isSelected}

--- a/components/table-row.js
+++ b/components/table-row.js
@@ -5,11 +5,10 @@ import {Table, Popover, Menu, Position, IconButton, toaster, Tooltip, EditIcon, 
 import TokenContext from '../contexts/token'
 import BalDataContext from '../contexts/bal-data'
 
-const TableRow = React.memo(({id, code, positions, label, comment, secondary, isSelectable, onSelect, onEdit, onRemove, handleSelect, isSelected, toponymeId}) => {
+const TableRow = React.memo(({id, code, label, warning, comment, secondary, isSelectable, onSelect, onEdit, onRemove, handleSelect, isSelected, toponymeId}) => {
   const [hovered, setHovered] = useState(false)
   const {token} = useContext(TokenContext)
   const {numeros, isEditing, toponymes} = useContext(BalDataContext)
-  const {type} = positions[0] || {}
   const hasNumero = numeros && numeros.length > 1
 
   const toponymeName = useMemo(() => {
@@ -100,9 +99,9 @@ const TableRow = React.memo(({id, code, positions, label, comment, secondary, is
           </Tooltip>
         </Table.Cell>
       )}
-      {type === 'inconnue' && (
+      {warning && (
         <Table.TextCell flex='0 1 1'>
-          <Tooltip content='Le type de la position est inconnu' position={Position.BOTTOM}>
+          <Tooltip content={warning} position={Position.BOTTOM}>
             <WarningSignIcon color='warning' style={{verticalAlign: 'bottom'}} />
           </Tooltip>
         </Table.TextCell>
@@ -154,7 +153,7 @@ const TableRow = React.memo(({id, code, positions, label, comment, secondary, is
 TableRow.propTypes = {
   id: PropTypes.string.isRequired,
   code: PropTypes.string,
-  positions: PropTypes.array,
+  warning: PropTypes.array,
   label: PropTypes.string.isRequired,
   comment: PropTypes.string,
   toponymeId: PropTypes.string,
@@ -169,7 +168,7 @@ TableRow.propTypes = {
 
 TableRow.defaultProps = {
   code: null,
-  positions: [],
+  warning: null,
   comment: null,
   toponymeId: null,
   secondary: null,

--- a/components/table-row.js
+++ b/components/table-row.js
@@ -1,17 +1,23 @@
-import React, {useState, useContext, useCallback} from 'react'
+import React, {useState, useContext, useCallback, useMemo} from 'react'
 import PropTypes from 'prop-types'
 import {Table, Popover, Menu, Position, IconButton, toaster, Tooltip, EditIcon, WarningSignIcon, CommentIcon, Checkbox, MoreIcon, SendToMapIcon, TrashIcon} from 'evergreen-ui'
 
 import TokenContext from '../contexts/token'
 import BalDataContext from '../contexts/bal-data'
 
-const TableRow = React.memo(({id, code, positions, label, comment, secondary, isSelectable, onSelect, onEdit, onRemove, handleSelect, isSelected, toponyme}) => {
+const TableRow = React.memo(({id, code, positions, label, comment, secondary, isSelectable, onSelect, onEdit, onRemove, handleSelect, isSelected, toponymeId}) => {
   const [hovered, setHovered] = useState(false)
   const {token} = useContext(TokenContext)
   const {numeros, isEditing, toponymes} = useContext(BalDataContext)
   const {type} = positions[0] || {}
   const hasNumero = numeros && numeros.length > 1
-  const toponymeName = toponyme ? toponymes.find(({_id}) => _id === toponyme).nom : null
+
+  const toponymeName = useMemo(() => {
+    if (toponymeId && toponymes) {
+      const toponyme = toponymes.find(({_id}) => _id === toponymeId)
+      return toponyme?.nom
+    }
+  }, [toponymeId, toponymes])
 
   const onClick = useCallback(e => {
     if (e.target.closest('[data-editable]') && !isEditing && !code) { // Not a commune
@@ -151,7 +157,7 @@ TableRow.propTypes = {
   positions: PropTypes.array,
   label: PropTypes.string.isRequired,
   comment: PropTypes.string,
-  toponyme: PropTypes.string,
+  toponymeId: PropTypes.string,
   secondary: PropTypes.string,
   isSelectable: PropTypes.bool,
   onSelect: PropTypes.func.isRequired,
@@ -165,7 +171,7 @@ TableRow.defaultProps = {
   code: null,
   positions: [],
   comment: null,
-  toponyme: null,
+  toponymeId: null,
   secondary: null,
   isSelectable: false,
   onEdit: null,

--- a/components/table-row.js
+++ b/components/table-row.js
@@ -5,10 +5,10 @@ import {Table, Popover, Menu, Position, IconButton, toaster, Tooltip, EditIcon, 
 import TokenContext from '../contexts/token'
 import BalDataContext from '../contexts/bal-data'
 
-const TableRow = React.memo(({id, code, positions, label, comment, secondary, isSelectable, onSelect, onEdit, onRemove, handleSelect, isSelected}) => {
+const TableRow = React.memo(({id, code, positions, label, comment, secondary, isSelectable, onSelect, onEdit, onRemove, handleSelect, isSelected, toponyme}) => {
   const [hovered, setHovered] = useState(false)
   const {token} = useContext(TokenContext)
-  const {numeros, numerosToponyme, isEditing} = useContext(BalDataContext)
+  const {numeros, numerosToponyme, isEditing, toponymes} = useContext(BalDataContext)
   const {type} = positions[0] || {}
   const hasNumero = (numeros && numeros.length > 1) || (numerosToponyme && numerosToponyme.length > 1)
 
@@ -65,12 +65,11 @@ const TableRow = React.memo(({id, code, positions, label, comment, secondary, is
           onMouseEnter={() => _onMouseEnter(id)}
           onMouseLeave={_onMouseLeave}
         >
-          {label} {hovered && !isEditing && (
+          {label} <i>{toponyme && toponymes && ' - ' + toponymes.find(t => t._id === toponyme).nom + ' '}</i> {hovered && !isEditing && (
             <EditIcon marginBottom={-4} marginLeft={8} />
           )}
         </Table.TextCell>
       </Table.Cell>
-      <Table.Cell data-browsable />
       {secondary && (
         <Table.TextCell flex='0 1 1'>
           {secondary}
@@ -133,6 +132,7 @@ TableRow.propTypes = {
   positions: PropTypes.array,
   label: PropTypes.string.isRequired,
   comment: PropTypes.string,
+  toponyme: PropTypes.string,
   secondary: PropTypes.string,
   isSelectable: PropTypes.bool,
   onSelect: PropTypes.func.isRequired,
@@ -146,6 +146,7 @@ TableRow.defaultProps = {
   code: null,
   positions: [],
   comment: null,
+  toponyme: null,
   secondary: null,
   isSelectable: true,
   onEdit: null,

--- a/components/table-row.js
+++ b/components/table-row.js
@@ -8,9 +8,9 @@ import BalDataContext from '../contexts/bal-data'
 const TableRow = React.memo(({id, code, positions, label, comment, secondary, isSelectable, onSelect, onEdit, onRemove, handleSelect, isSelected, toponyme}) => {
   const [hovered, setHovered] = useState(false)
   const {token} = useContext(TokenContext)
-  const {numeros, numerosToponyme, isEditing, toponymes} = useContext(BalDataContext)
+  const {numeros, isEditing, toponymes} = useContext(BalDataContext)
   const {type} = positions[0] || {}
-  const hasNumero = (numeros && numeros.length > 1) || (numerosToponyme && numerosToponyme.length > 1)
+  const hasNumero = numeros && numeros.length > 1
 
   const onClick = useCallback(e => {
     if (e.target.closest('[data-editable]') && !isEditing && !code) { // Not a commune

--- a/components/table-row.js
+++ b/components/table-row.js
@@ -15,12 +15,12 @@ const TableRow = React.memo(({id, code, positions, label, comment, secondary, is
   const onClick = useCallback(e => {
     if (e.target.closest('[data-editable]') && !isEditing && !code) { // Not a commune
       onEdit(id)
-    } else if (isSelectable) {
+    } else if (onSelect) {
       if (e.target.closest('[data-browsable]')) {
         onSelect(id)
       }
     }
-  }, [code, id, isSelectable, isEditing, onEdit, onSelect])
+  }, [code, id, isEditing, onEdit, onSelect])
 
   const _onEdit = useCallback(() => {
     onEdit(id)
@@ -45,7 +45,7 @@ const TableRow = React.memo(({id, code, positions, label, comment, secondary, is
   }, [])
 
   return (
-    <Table.Row style={{backgroundColor: hovered ? '#f5f6f7' : ''}} onClick={onClick}>
+    <Table.Row onClick={onClick}>
       {token && !isEditing && hasNumero && isSelectable && (
         <Table.Cell flex='0 1 1'>
           <Checkbox
@@ -57,16 +57,24 @@ const TableRow = React.memo(({id, code, positions, label, comment, secondary, is
       {code && (
         <Table.TextCell data-browsable isNumber flex='0 1 1'>{code}</Table.TextCell>
       )}
-      <Table.Cell data-browsable>
+      <Table.Cell
+        data-browsable
+        style={onSelect ? {cursor: 'pointer', backgroundColor: hovered ? '#E4E7EB' : '#f5f6f7'} : null}
+        onMouseEnter={() => _onMouseEnter(id)}
+        onMouseLeave={_onMouseLeave}
+      >
         <Table.TextCell
           data-editable
           flex='0 1 1'
           style={{cursor: onEdit && !isEditing ? 'text' : 'default'}}
-          onMouseEnter={() => _onMouseEnter(id)}
-          onMouseLeave={_onMouseLeave}
+          className='edit-cell'
         >
-          {label} <i>{toponyme && toponymes && ` - ${toponymes.find(t => t._id === toponyme).nom} `}</i> {hovered && !isEditing && (
-            <EditIcon marginBottom={-4} marginLeft={8} />
+          {label} <i>{toponyme && ` - ${toponymes.find(t => t._id === toponyme).nom} `}</i>
+          {!isEditing && onEdit && (
+            <span className='pencil-icon'>
+              <EditIcon marginBottom={-4} marginLeft={8} />
+            </span>
+
           )}
         </Table.TextCell>
       </Table.Cell>
@@ -99,7 +107,7 @@ const TableRow = React.memo(({id, code, positions, label, comment, secondary, is
             content={
               <Menu>
                 <Menu.Group>
-                  {isSelectable && (
+                  {onSelect && (
                     <Menu.Item icon={SendToMapIcon} onSelect={() => onSelect(id)}>
                       Consulter
                     </Menu.Item>
@@ -122,6 +130,16 @@ const TableRow = React.memo(({id, code, positions, label, comment, secondary, is
           </Popover>
         </Table.TextCell>
       )}
+
+      <style global jsx>{`
+        .edit-cell .pencil-icon {
+          display: none;
+        }
+
+        .edit-cell:hover .pencil-icon {
+          display: inline-block;
+        }
+        `}</style>
     </Table.Row>
   )
 })

--- a/components/table-row.js
+++ b/components/table-row.js
@@ -11,6 +11,7 @@ const TableRow = React.memo(({id, code, positions, label, comment, secondary, is
   const {numeros, isEditing, toponymes} = useContext(BalDataContext)
   const {type} = positions[0] || {}
   const hasNumero = numeros && numeros.length > 1
+  const toponymeName = toponyme ? toponymes.find(({_id}) => _id === toponyme).nom : null
 
   const onClick = useCallback(e => {
     if (e.target.closest('[data-editable]') && !isEditing && !code) { // Not a commune
@@ -69,7 +70,7 @@ const TableRow = React.memo(({id, code, positions, label, comment, secondary, is
           style={{cursor: onEdit && !isEditing ? 'text' : 'default'}}
           className='edit-cell'
         >
-          {label} <i>{toponyme && ` - ${toponymes.find(t => t._id === toponyme).nom} `}</i>
+          {label} <i>{toponymeName && ` - ${toponymeName}`}</i>
           {!isEditing && onEdit && (
             <span className='pencil-icon'>
               <EditIcon marginBottom={-4} marginLeft={8} />

--- a/components/table-row.js
+++ b/components/table-row.js
@@ -45,8 +45,8 @@ const TableRow = React.memo(({id, code, positions, label, comment, secondary, is
   }, [])
 
   return (
-    <Table.Row isSelectable={isSelectable} style={{backgroundColor: hovered ? '#f5f6f7' : ''}} onClick={onClick}>
-      {token && !isEditing && hasNumero && (
+    <Table.Row style={{backgroundColor: hovered ? '#f5f6f7' : ''}} onClick={onClick}>
+      {token && !isEditing && hasNumero && isSelectable && (
         <Table.Cell flex='0 1 1'>
           <Checkbox
             checked={isSelected}
@@ -65,7 +65,7 @@ const TableRow = React.memo(({id, code, positions, label, comment, secondary, is
           onMouseEnter={() => _onMouseEnter(id)}
           onMouseLeave={_onMouseLeave}
         >
-          {label} <i>{toponyme && toponymes && ' - ' + toponymes.find(t => t._id === toponyme).nom + ' '}</i> {hovered && !isEditing && (
+          {label} <i>{toponyme && toponymes && ` - ${toponymes.find(t => t._id === toponyme).nom} `}</i> {hovered && !isEditing && (
             <EditIcon marginBottom={-4} marginLeft={8} />
           )}
         </Table.TextCell>
@@ -148,7 +148,7 @@ TableRow.defaultProps = {
   comment: null,
   toponyme: null,
   secondary: null,
-  isSelectable: true,
+  isSelectable: false,
   onEdit: null,
   handleSelect: null,
   isSelected: false

--- a/components/toponyme/add-numeros.js
+++ b/components/toponyme/add-numeros.js
@@ -50,6 +50,7 @@ function AddNumeros({onSubmit, onCancel, isLoading}) {
     const numeros = selectedVoieNumeros.length > 0 ?
       selectedVoieNumeros :
       voieNumeros.map(({_id}) => _id)
+
     onSubmit(numeros)
   }, [selectedVoieNumeros, voieNumeros, onSubmit])
 
@@ -84,7 +85,7 @@ function AddNumeros({onSubmit, onCancel, isLoading}) {
                 isMultiSelect
                 hasFilter={false}
                 title='Sélection des numéros'
-                options={voieNumeros.map(({_id, numero}) => ({label: `${numero}`, value: _id}))}
+                options={voieNumeros.map(({_id, numero, suffixe}) => ({label: `${numero}${suffixe ? suffixe : ''}`, value: _id}))}
                 selected={selectedVoieNumeros}
                 emptyView={(
                   <Pane height='100%' paddingX='1em' display='flex' alignItems='center' justifyContent='center' textAlign='center'>

--- a/components/toponyme/add-numeros.js
+++ b/components/toponyme/add-numeros.js
@@ -1,0 +1,142 @@
+import React, {useState, useCallback, useContext, useMemo} from 'react'
+import PropTypes from 'prop-types'
+import {sortBy} from 'lodash'
+import {SelectField, SelectMenu, Pane, Button, Alert, Text} from 'evergreen-ui'
+
+import {normalizeSort} from '../../lib/normalize'
+import {getNumeros} from '../../lib/bal-api'
+
+import BalDataContext from '../../contexts/bal-data'
+
+function AddNumeros({onSubmit, onCancel, isLoading}) {
+  const [selectedVoie, setSelectedVoie] = useState(null)
+  const [voieNumeros, setVoieNumeros] = useState([])
+  const [selectedVoieNumeros, setSelectedVoieNumeros] = useState([])
+
+  const {voies} = useContext(BalDataContext)
+
+  const handleSelectVoie = async idVoie => {
+    setSelectedVoie(idVoie)
+    if (idVoie) {
+      const numeros = await getNumeros(idVoie)
+      setVoieNumeros(numeros)
+    }
+  }
+
+  const handleSelectNumero = ({value}) => {
+    setSelectedVoieNumeros(selectedNumeros => {
+      return selectedNumeros.includes(value) ?
+        selectedNumeros.filter(id => id !== value) :
+        [...selectedNumeros, value]
+    })
+  }
+
+  const numerosLabel = useMemo(() => {
+    const selectedNumeroCount = selectedVoieNumeros.length
+    if (selectedNumeroCount === 0) {
+      return 'Choisir les numéros'
+    }
+
+    if (selectedNumeroCount === 1) {
+      const numero = voieNumeros.find(({_id}) => _id === selectedVoieNumeros[0])
+      const voie = voies.find(({_id}) => _id === selectedVoie)
+      return `le ${numero.numero} ${voie.nom}`
+    }
+
+    return `${selectedNumeroCount} numéros sélectionnés`
+  }, [selectedVoie, voieNumeros, selectedVoieNumeros, voies])
+
+  const handleSubmit = useCallback(() => {
+    const numeros = selectedVoieNumeros.length > 0 ?
+      selectedVoieNumeros :
+      voieNumeros.map(({_id}) => _id)
+    onSubmit(numeros)
+  }, [selectedVoieNumeros, voieNumeros, onSubmit])
+
+  return (
+    <Pane>
+      <Pane display='flex'>
+        <SelectField
+          label='Voie'
+          flex={1}
+          marginBottom={16}
+          onChange={e => handleSelectVoie(e.target.value)}
+        >
+          <option value={null}>- Sélectionnez une voie -</option>
+          {sortBy(voies, v => normalizeSort(v.nom)).map(({_id, nom}) => (
+            <option key={_id} value={_id} selected={_id === selectedVoie}>
+              {nom}
+            </option>
+          ))}
+        </SelectField>
+      </Pane>
+
+      {selectedVoie && (
+        <>
+
+          <Alert marginY={8} title='Préciser les numéros à ajouter au toponyme'>
+            <Text>
+              Sélectionnez les numéros que vous souhaitez ajouter au toponyme. Si aucun numéro n’est spécifié, alors tous les numéros de la voie seront ajoutés.
+            </Text>
+
+            <Pane diplay='flex'>
+              <SelectMenu
+                isMultiSelect
+                hasFilter={false}
+                title='Sélection des numéros'
+                options={voieNumeros.map(({_id, numero}) => ({label: `${numero}`, value: _id}))}
+                selected={selectedVoieNumeros}
+                emptyView={(
+                  <Pane height='100%' paddingX='1em' display='flex' alignItems='center' justifyContent='center' textAlign='center'>
+                    <Text size={300}>Aucun numéro n’est disponible pour cette voie</Text>
+                  </Pane>
+                )}
+                onSelect={handleSelectNumero}
+                onDeselect={handleSelectNumero}
+              >
+                <Button marginTop={8} type='div'>
+                  {numerosLabel}
+                </Button>
+              </SelectMenu>
+            </Pane>
+          </Alert>
+        </>
+      )}
+
+      <Button
+        isLoading={isLoading}
+        type='submit'
+        appearance='primary'
+        intent='success'
+        disabled={!(selectedVoie && voieNumeros.length > 0)}
+        marginTop={16}
+        onClick={handleSubmit}
+      >
+        {isLoading ? 'Enregistrement…' : 'Enregistrer'}
+      </Button>
+
+      <Button
+        disabled={isLoading}
+        appearance='minimal'
+        marginLeft={8}
+        marginTop={16}
+        display='inline-flex'
+        onClick={onCancel}
+      >
+        Annuler
+      </Button>
+    </Pane>
+  )
+}
+
+AddNumeros.defaultProps = {
+  isLoading: false
+}
+
+AddNumeros.propTypes = {
+  isLoading: PropTypes.bool,
+  onSubmit: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired
+}
+
+export default AddNumeros

--- a/components/toponyme/toponyme-numeros.js
+++ b/components/toponyme/toponyme-numeros.js
@@ -1,0 +1,46 @@
+import React, {useState, useMemo} from 'react'
+import PropTypes from 'prop-types'
+import {groupBy} from 'lodash'
+import {Heading, Table, EditIcon} from 'evergreen-ui'
+
+function ToponymeNumeros({numeros, handleSelect}) {
+  const [hovered, setHovered] = useState(null)
+
+  const numerosByVoie = useMemo(() => {
+    return groupBy(numeros.sort((a, b) => a.numero - b.numero), d => d.voie[0].nom)
+  }, [numeros])
+
+  return (
+    Object.keys(numerosByVoie).map(nomVoie => (
+      <>
+        <Table.Cell style={{padding: 0}}>
+          <Heading padding='1em' backgroundColor='white' width='100%'>
+            {nomVoie}
+          </Heading>
+        </Table.Cell>
+        {numerosByVoie[nomVoie].map(({_id, numero, suffixe}) => (
+          <Table.Row
+            key={_id}
+            style={{cursor: 'pointer', backgroundColor: hovered === _id ? '#E4E7EB' : '#f5f6f7'}}
+            onMouseEnter={() => setHovered(_id)}
+            onMouseLeave={() => setHovered(null)}
+            onClick={() => handleSelect(_id)}
+          >
+            <Table.Cell data-browsable>
+              <Table.TextCell data-editable flex='0 1 1'>
+                {numero}{suffixe} {hovered === _id && <EditIcon marginBottom={-4} marginLeft={8} />}
+              </Table.TextCell>
+            </Table.Cell>
+          </Table.Row>
+        ))}
+      </>
+    ))
+  )
+}
+
+ToponymeNumeros.propTypes = {
+  numeros: PropTypes.array.isRequired,
+  handleSelect: PropTypes.func.isRequired
+}
+
+export default ToponymeNumeros

--- a/components/toponyme/toponyme-numeros.js
+++ b/components/toponyme/toponyme-numeros.js
@@ -1,7 +1,7 @@
 import React, {useState, useMemo, useContext} from 'react'
 import PropTypes from 'prop-types'
 import {groupBy} from 'lodash'
-import {Heading, Table, EditIcon} from 'evergreen-ui'
+import {Heading, Table, EditIcon, Tooltip, CommentIcon, WarningSignIcon, Position} from 'evergreen-ui'
 
 import TokenContext from '../../contexts/token'
 
@@ -21,7 +21,7 @@ function ToponymeNumeros({numeros, handleSelect}) {
             {nomVoie}
           </Heading>
         </Table.Cell>
-        {numerosByVoie[nomVoie].map(({_id, numero, suffixe}) => (
+        {numerosByVoie[nomVoie].map(({_id, numero, suffixe, positions, comment}) => (
           <Table.Row
             key={_id}
             style={{cursor: 'pointer', backgroundColor: hovered === _id ? '#E4E7EB' : '#f5f6f7'}}
@@ -34,6 +34,31 @@ function ToponymeNumeros({numeros, handleSelect}) {
                 {numero}{suffixe} {hovered === _id && token && <EditIcon marginBottom={-4} marginLeft={8} />}
               </Table.TextCell>
             </Table.Cell>
+
+            {positions.length > 1 && (
+              <Table.TextCell flex='0 1 1'>
+                {`${positions.length} positions`}
+              </Table.TextCell>
+            )}
+
+            {comment && (
+              <Table.Cell flex='0 1 1'>
+                <Tooltip
+                  content={comment}
+                  position={Position.BOTTOM_RIGHT}
+                >
+                  <CommentIcon color='muted' />
+                </Tooltip>
+              </Table.Cell>
+            )}
+
+            {positions.find(p => p.type === 'inconnue') && (
+              <Table.TextCell flex='0 1 1'>
+                <Tooltip content='Le type d’une position est inconnu' position={Position.BOTTOM}>
+                  <WarningSignIcon color='warning' style={{verticalAlign: 'bottom'}} />
+                </Tooltip>
+              </Table.TextCell>
+            )}
           </Table.Row>
         ))}
       </>

--- a/components/toponyme/toponyme-numeros.js
+++ b/components/toponyme/toponyme-numeros.js
@@ -1,10 +1,13 @@
-import React, {useState, useMemo} from 'react'
+import React, {useState, useMemo, useContext} from 'react'
 import PropTypes from 'prop-types'
 import {groupBy} from 'lodash'
 import {Heading, Table, EditIcon} from 'evergreen-ui'
 
+import TokenContext from '../../contexts/token'
+
 function ToponymeNumeros({numeros, handleSelect}) {
   const [hovered, setHovered] = useState(null)
+  const {token} = useContext(TokenContext)
 
   const numerosByVoie = useMemo(() => {
     return groupBy(numeros.sort((a, b) => a.numero - b.numero), d => d.voie[0].nom)
@@ -28,7 +31,7 @@ function ToponymeNumeros({numeros, handleSelect}) {
           >
             <Table.Cell data-browsable>
               <Table.TextCell data-editable flex='0 1 1'>
-                {numero}{suffixe} {hovered === _id && <EditIcon marginBottom={-4} marginLeft={8} />}
+                {numero}{suffixe} {hovered === _id && token && <EditIcon marginBottom={-4} marginLeft={8} />}
               </Table.TextCell>
             </Table.Cell>
           </Table.Row>

--- a/contexts/bal-data.js
+++ b/contexts/bal-data.js
@@ -14,7 +14,6 @@ export const BalDataContextProvider = React.memo(({balId, codeCommune, idVoie, i
   const [editingId, _setEditingId] = useState()
   const [geojson, setGeojson] = useState()
   const [numeros, setNumeros] = useState()
-  const [numerosToponyme, setNumerosToponyme] = useState()
   const [voies, setVoies] = useState()
   const [toponymes, setToponymes] = useState()
   const [voie, setVoie] = useState()
@@ -69,12 +68,12 @@ export const BalDataContextProvider = React.memo(({balId, codeCommune, idVoie, i
 
     if (id) {
       const toponyme = await getToponyme(id)
-      const numerosToponyme = await getNumerosToponyme(id)
+      const numeros = await getNumerosToponyme(id)
       setToponyme(toponyme)
-      setNumerosToponyme(numerosToponyme)
+      setNumeros(numeros)
     } else {
       setToponyme(null)
-      setNumerosToponyme(null)
+      setNumeros(null)
     }
   }, [idToponyme])
 
@@ -137,8 +136,7 @@ export const BalDataContextProvider = React.memo(({balId, codeCommune, idVoie, i
         reloadToponymes,
         reloadBaseLocale,
         reloadNumerosToponyme,
-        toponyme,
-        numerosToponyme
+        toponyme
       }}
       {...props}
     />

--- a/lib/bal-api/index.js
+++ b/lib/bal-api/index.js
@@ -221,6 +221,50 @@ export function removeVoie(idVoie, token) {
   })
 }
 
+export function getToponymes(balId, codeCommune) {
+  return request(`/bases-locales/${balId}/communes/${codeCommune}/toponymes`)
+}
+
+export function getToponyme(idToponyme) {
+  return request(`/toponymes/${idToponyme}`)
+}
+
+export function addToponyme(balId, codeCommune, body, token) {
+  return request(`/bases-locales/${balId}/communes/${codeCommune}/toponymes`, {
+    method: 'POST',
+    headers: {
+      authorization: `Token ${token}`,
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify(body)
+  })
+}
+
+export function editToponyme(idToponyme, body, token) {
+  return request(`/toponymes/${idToponyme}`, {
+    method: 'PUT',
+    headers: {
+      authorization: `Token ${token}`,
+      'content-type': 'application/json'
+    },
+    body: JSON.stringify(body)
+  })
+}
+
+export function removeToponyme(idToponyme, token) {
+  return request(`/toponymes/${idToponyme}`, {
+    json: false,
+    method: 'DELETE',
+    headers: {
+      authorization: `Token ${token}`
+    }
+  })
+}
+
+export function getNumerosToponyme(idToponyme) {
+  return request(`/toponymes/${idToponyme}/numeros`)
+}
+
 export function getNumeros(idVoie) {
   return request(`/voies/${idVoie}/numeros`)
 }

--- a/lib/voie.js
+++ b/lib/voie.js
@@ -1,12 +1,3 @@
-export function getFullVoieName(voie, isComplementEnable = false) {
-  const {nom, complement} = voie
-  if (isComplementEnable) {
-    return `${nom} ${complement ? `(${complement})` : ''}`
-  }
-
-  return nom
-}
-
 export function checkIsToponyme(voie) {
   const {positions, isMetric} = voie || {}
   const position = positions ? positions[0] : null

--- a/lib/voie.js
+++ b/lib/voie.js
@@ -1,6 +1,0 @@
-export function checkIsToponyme(voie) {
-  const {positions, isMetric} = voie || {}
-  const position = positions ? positions[0] : null
-
-  return Boolean(position && !isMetric)
-}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -110,7 +110,7 @@ function App({error, Component, pageProps, query}) {
 
                   {pageProps.baseLocale && (
                     <SettingsContextProvider>
-                      <Settings nomBaseLocale={pageProps.baseLocale.nom} isEnabledComplement={pageProps.baseLocale.enableComplement} />
+                      <Settings nomBaseLocale={pageProps.baseLocale.nom} />
                       <Header />
                       <SubHeader
                         {...pageProps}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -129,6 +129,7 @@ function App({error, Component, pageProps, query}) {
                       interactive={layout === 'sidebar'}
                       commune={pageProps.commune}
                       voie={pageProps.voie}
+                      toponyme={pageProps.toponyme}
                     />
                   )}
 

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import Head from 'next/head'
 import {Pane, Dialog, Paragraph} from 'evergreen-ui'
 
-import {getBaseLocale, getVoie} from '../lib/bal-api'
+import {getBaseLocale, getVoie, getToponyme} from '../lib/bal-api'
 import {getCommune} from '../lib/geo-api'
 
 import SubHeader from '../components/sub-header'
@@ -100,7 +100,7 @@ function App({error, Component, pageProps, query}) {
       </Pane>
 
       <TokenContextProvider balId={query.balId} _token={query.token}>
-        <BalDataContextProvider balId={query.balId} codeCommune={query.codeCommune} idVoie={query.idVoie}>
+        <BalDataContextProvider balId={query.balId} codeCommune={query.codeCommune} idVoie={query.idVoie} idToponyme={query.idToponyme}>
           <MapContextProvider>
             <DrawContextProvider>
               <MarkersContextProvider>
@@ -172,6 +172,7 @@ App.getInitialProps = async ({Component, ctx}) => {
   let baseLocale
   let commune
   let voie
+  let toponyme
 
   if (query.balId) {
     try {
@@ -202,12 +203,17 @@ App.getInitialProps = async ({Component, ctx}) => {
     voie = await getVoie(query.idVoie)
   }
 
+  if (query.idToponyme) {
+    toponyme = await getToponyme(query.idToponyme)
+  }
+
   if (Component.getInitialProps) {
     pageProps = await Component.getInitialProps({
       ...ctx,
       baseLocale,
       commune,
-      voie
+      voie,
+      toponyme
     })
   }
 

--- a/pages/bal/commune.js
+++ b/pages/bal/commune.js
@@ -45,14 +45,13 @@ const Commune = React.memo(({commune, defaultVoies}) => {
     setIsPopulating(false)
   }, [baseLocale, commune, reloadVoies, token])
 
-  const onAdd = useCallback(async ({nom, positions, typeNumerotation, trace, complement}) => {
+  const onAdd = useCallback(async ({nom, positions, typeNumerotation, trace}) => {
     if (selectedTab === 'voie') {
       const voie = await addVoie(baseLocale._id, commune.code, {
         nom,
         typeNumerotation,
         positions,
-        trace,
-        complement
+        trace
       }, token)
 
       Router.push(
@@ -87,14 +86,13 @@ const Commune = React.memo(({commune, defaultVoies}) => {
     setEditingId(id)
   }, [setEditingId])
 
-  const onEdit = useCallback(async ({nom, typeNumerotation, trace, positions, complement}) => {
+  const onEdit = useCallback(async ({nom, typeNumerotation, trace, positions}) => {
     if (selectedTab === 'voie') {
       await editVoie(editingId, {
         nom,
         typeNumerotation,
         trace,
-        positions,
-        complement
+        positions
       }, token)
 
       await reloadVoies()

--- a/pages/bal/commune.js
+++ b/pages/bal/commune.js
@@ -34,7 +34,7 @@ const Commune = React.memo(({commune, defaultVoies}) => {
     setIsEditing
   } = useContext(BalDataContext)
 
-  useHelp(2)
+  useHelp(selectedTab === 'voie' ? 2 : 3)
 
   const onPopulate = useCallback(async () => {
     setIsPopulating(true)

--- a/pages/bal/commune.js
+++ b/pages/bal/commune.js
@@ -4,7 +4,7 @@ import Router from 'next/router'
 import {sortBy} from 'lodash'
 import {Pane, Heading, Text, Paragraph, Table, Button, AddIcon, Tab} from 'evergreen-ui'
 
-import {getVoies, addVoie, populateCommune, editVoie, removeVoie, getNumeros, addToponyme, editToponyme, removeToponyme} from '../../lib/bal-api'
+import {getVoies, addVoie, populateCommune, editVoie, removeVoie, addToponyme, editToponyme, removeToponyme} from '../../lib/bal-api'
 
 import TokenContext from '../../contexts/token'
 import BalDataContext from '../../contexts/bal-data'
@@ -23,7 +23,6 @@ const Commune = React.memo(({commune, defaultVoies}) => {
   const [isAdding, setIsAdding] = useState(false)
   const [isPopulating, setIsPopulating] = useState(false)
   const [toRemove, setToRemove] = useState(null)
-  const [selectedVoieHasNumeros, setSelectedVoieHasNumeros] = useState(false)
   const [selectedTab, setSelectedTab] = useState('voie')
 
   const {token} = useContext(TokenContext)
@@ -99,12 +98,9 @@ const Commune = React.memo(({commune, defaultVoies}) => {
   }, [])
 
   const onEnableEditing = useCallback(async idVoie => {
-    const numeros = await getNumeros(idVoie)
-
-    setSelectedVoieHasNumeros(numeros.length > 0)
     setIsAdding(false)
     setEditingId(idVoie)
-  }, [setEditingId, setSelectedVoieHasNumeros])
+  }, [setEditingId])
 
   const onEnableEditingToponyme = useCallback(async idToponyme => {
     setIsAdding(false)
@@ -165,12 +161,6 @@ const Commune = React.memo(({commune, defaultVoies}) => {
     setIsAdding(false)
     setEditingId(null)
   }, [setEditingId])
-
-  useEffect(() => {
-    if (!editingId) {
-      setSelectedVoieHasNumeros(false)
-    }
-  }, [editingId])
 
   useEffect(() => {
     setIsEditing(isAdding)
@@ -292,7 +282,6 @@ const Commune = React.memo(({commune, defaultVoies}) => {
                 <Table.Row key={voie._id} height='auto'>
                   <Table.Cell display='block' paddingY={12} background='tint1'>
                     <VoieEditor
-                      hasNumeros={selectedVoieHasNumeros}
                       isEnabledComplement={Boolean(baseLocale.enableComplement)}
                       initialValue={voie}
                       onSubmit={onEdit}

--- a/pages/bal/commune.js
+++ b/pages/bal/commune.js
@@ -46,6 +46,7 @@ const Commune = React.memo(({commune, defaultVoies}) => {
       'nom'
     ]
   })
+  const [filteredToponymes, setFilteredToponymes] = useFuse(toponymes, 200, {keys: ['nom']})
 
   const onPopulate = useCallback(async () => {
     setIsPopulating(true)
@@ -252,8 +253,8 @@ const Commune = React.memo(({commune, defaultVoies}) => {
         <Table>
           <Table.Head>
             <Table.SearchHeaderCell
-              placeholder='Rechercher une voie'
-              onChange={setFilter}
+              placeholder={`Rechercher ${selectedTab === 'voie' ? 'une voie' : 'un toponyme'}`}
+              onChange={selectedTab === 'voie' ? setFilter : setFilteredToponymes}
             />
           </Table.Head>
           {isAdding && selectedTab === 'voie' && (
@@ -312,27 +313,28 @@ const Commune = React.memo(({commune, defaultVoies}) => {
                     onRemove={id => setToRemove(id)}
                   />)
               ))) : (
-            toponymes.map(toponyme => toponyme._id === editingId ? (
-              <Table.Row key={toponyme._id} height='auto'>
-                <Table.Cell display='block' paddingY={12} background='tint1'>
-                  <ToponymeEditor
-                    initialValue={toponyme}
-                    onSubmit={onEditToponyme}
-                    onCancel={onCancel}
-                  />
-                </Table.Cell>
-              </Table.Row>
-            ) : (
-              <TableRow
-                key={toponyme._id}
-                id={toponyme._id}
-                isSelectable={!isEditing && !isPopulating}
-                label={toponyme.nom}
-                onSelect={onSelectToponyme}
-                onEdit={onEnableEditingToponyme}
-                onRemove={id => setToRemove(id)}
-              />
-            )))}
+            sortBy(filteredToponymes, t => normalizeSort(t.nom))
+              .map(toponyme => toponyme._id === editingId ? (
+                <Table.Row key={toponyme._id} height='auto'>
+                  <Table.Cell display='block' paddingY={12} background='tint1'>
+                    <ToponymeEditor
+                      initialValue={toponyme}
+                      onSubmit={onEditToponyme}
+                      onCancel={onCancel}
+                    />
+                  </Table.Cell>
+                </Table.Row>
+              ) : (
+                <TableRow
+                  key={toponyme._id}
+                  id={toponyme._id}
+                  isSelectable={!isEditing && !isPopulating}
+                  label={toponyme.nom}
+                  onSelect={onSelectToponyme}
+                  onEdit={onEnableEditingToponyme}
+                  onRemove={id => setToRemove(id)}
+                />
+              )))}
         </Table>
       </Pane>
       {token && voies && voies.length === 0 && (

--- a/pages/bal/commune.js
+++ b/pages/bal/commune.js
@@ -180,17 +180,15 @@ const Commune = React.memo(({commune, defaultVoies}) => {
         flexShrink={0}
         elevation={0}
         backgroundColor='white'
-        padding={16}
         width='100%'
-        margin='auto'
         display='flex'
         justifyContent='space-around'
-        minHeight={64}
+        height={38}
       >
-        <Tab isSelected={selectedTab === 'voie'} onClick={() => setSelectedTab('voie')}>
+        <Tab width='100%' height='100%' margin='0' isSelected={selectedTab === 'voie'} onClick={() => setSelectedTab('voie')}>
           <Heading>Liste des voies</Heading>
         </Tab>
-        <Tab isSelected={selectedTab === 'toponyme'} onClick={() => setSelectedTab('toponyme')}>
+        <Tab width='100%' height='100%' margin='0' isSelected={selectedTab === 'toponyme'} onClick={() => setSelectedTab('toponyme')}>
           <Heading>Liste des toponymes</Heading>
         </Tab>
       </Pane>

--- a/pages/bal/commune.js
+++ b/pages/bal/commune.js
@@ -175,6 +175,12 @@ const Commune = React.memo(({commune, defaultVoies}) => {
     setIsEditing(isAdding)
   }, [isAdding, setIsEditing])
 
+  useEffect(() => {
+    if (editingId && toponymes.find(toponyme => toponyme._id === editingId)) {
+      setSelectedTab('toponyme')
+    }
+  }, [toponymes, editingId])
+
   return (
     <>
       <DeleteWarning

--- a/pages/bal/commune.js
+++ b/pages/bal/commune.js
@@ -50,7 +50,6 @@ const Commune = React.memo(({commune, defaultVoies}) => {
       const voie = await addVoie(baseLocale._id, commune.code, {
         nom,
         typeNumerotation,
-        positions,
         trace
       }, token)
 
@@ -91,8 +90,7 @@ const Commune = React.memo(({commune, defaultVoies}) => {
       await editVoie(editingId, {
         nom,
         typeNumerotation,
-        trace,
-        positions
+        trace
       }, token)
 
       await reloadVoies()

--- a/pages/bal/toponyme-heading.js
+++ b/pages/bal/toponyme-heading.js
@@ -59,7 +59,7 @@ const ToponymeHeading = ({defaultToponyme}) => {
           onMouseLeave={() => setHovered(false)}
         >
           {toponyme.nom}
-          {!isEditing && (
+          {!isEditing && token && (
             <EditIcon
               marginBottom={-2}
               marginLeft={8}

--- a/pages/bal/toponyme-heading.js
+++ b/pages/bal/toponyme-heading.js
@@ -22,12 +22,9 @@ const ToponymeHeading = ({defaultToponyme}) => {
     }
   }, [setEditingId, isEditing, toponyme._id])
 
-  const onEditToponyme = useCallback(async ({nom, typeNumerotation, trace, complement, positions}) => {
+  const onEditToponyme = useCallback(async ({nom, positions}) => {
     const editedToponyme = await editToponyme(toponyme._id, {
       nom,
-      typeNumerotation,
-      trace,
-      complement,
       positions
     }, token)
 

--- a/pages/bal/toponyme-heading.js
+++ b/pages/bal/toponyme-heading.js
@@ -1,0 +1,89 @@
+import React, {useState, useCallback, useContext, useEffect} from 'react'
+import PropTypes from 'prop-types'
+import {Pane, Heading, EditIcon, Text} from 'evergreen-ui'
+
+import {editToponyme} from '../../lib/bal-api'
+
+import TokenContext from '../../contexts/token'
+import BalDataContext from '../../contexts/bal-data'
+
+import ToponymeEditor from '../../components/bal/toponyme-editor'
+
+const ToponymeHeading = ({defaultToponyme}) => {
+  const [toponyme, setToponyme] = useState(defaultToponyme)
+  const [hovered, setHovered] = useState(false)
+  const {token} = useContext(TokenContext)
+  const {editingId, setEditingId, isEditing, reloadToponymes, numeros} = useContext(BalDataContext)
+
+  const onEnableToponymeEditing = useCallback(() => {
+    if (!isEditing) {
+      setEditingId(toponyme._id)
+      setHovered(false)
+    }
+  }, [setEditingId, isEditing, toponyme._id])
+
+  const onEditToponyme = useCallback(async ({nom, typeNumerotation, trace, complement, positions}) => {
+    const editedToponyme = await editToponyme(toponyme._id, {
+      nom,
+      typeNumerotation,
+      trace,
+      complement,
+      positions
+    }, token)
+
+    setEditingId(null)
+    await reloadToponymes()
+
+    setToponyme(editedToponyme)
+  }, [reloadToponymes, setEditingId, token, toponyme])
+
+  useEffect(() => {
+    setToponyme(defaultToponyme)
+  }, [defaultToponyme])
+
+  return (
+    <Pane
+      display='flex'
+      flexDirection='column'
+      background='tint1'
+      padding={16}
+    >
+      {editingId === toponyme._id ? (
+        <ToponymeEditor
+          initialValue={toponyme}
+          onSubmit={onEditToponyme}
+          onCancel={() => setEditingId(null)}
+        />
+      ) : (
+        <Heading
+          style={{cursor: hovered && !isEditing ? 'text' : 'default'}}
+          onClick={onEnableToponymeEditing}
+          onMouseEnter={() => setHovered(true)}
+          onMouseLeave={() => setHovered(false)}
+        >
+          {toponyme.nom}
+          {!isEditing && (
+            <EditIcon
+              marginBottom={-2}
+              marginLeft={8}
+              color={hovered ? 'black' : 'muted'}
+            />
+          )}
+        </Heading>
+      )}
+      {numeros && (
+        <Text>{numeros.length} numéro{numeros.length > 1 ? 's' : ''}</Text>
+      )}
+    </Pane>
+  )
+}
+
+ToponymeHeading.propTypes = {
+  defaultToponyme: PropTypes.shape({
+    _id: PropTypes.string.isRequired,
+    nom: PropTypes.string.isRequired,
+    positions: PropTypes.array.isRequired
+  }).isRequired
+}
+
+export default ToponymeHeading

--- a/pages/bal/toponyme.js
+++ b/pages/bal/toponyme.js
@@ -295,6 +295,7 @@ const Toponyme = (({toponyme, defaultNumeros}) => {
                     comment={numero.comment}
                     isSelectable={!isEditing && !numero}
                     label={numero.numero}
+                    toponyme={null}
                     secondary={numero.positions.length > 1 ? `${numero.positions.length} positions` : null}
                     handleSelect={handleSelect}
                     isSelected={selectedNumerosIds.includes(numero._id)}

--- a/pages/bal/toponyme.js
+++ b/pages/bal/toponyme.js
@@ -28,7 +28,7 @@ const Toponyme = (({toponyme, defaultNumeros}) => {
   const {token} = useContext(TokenContext)
 
   const {
-    numerosToponyme,
+    numeros,
     reloadNumerosToponyme,
     editingId,
     setEditingId,
@@ -37,7 +37,7 @@ const Toponyme = (({toponyme, defaultNumeros}) => {
   } = useContext(BalDataContext)
 
   useHelp(3)
-  const [filtered, setFilter] = useFuse(numerosToponyme || defaultNumeros, 200, {
+  const [filtered, setFilter] = useFuse(numeros || defaultNumeros, 200, {
     keys: [
       'numero'
     ]
@@ -48,19 +48,19 @@ const Toponyme = (({toponyme, defaultNumeros}) => {
   const [selectedNumerosIds, setSelectedNumerosIds] = useState([])
 
   const isGroupedActionsShown = useMemo(() => token && selectedNumerosIds.length > 1, [token, selectedNumerosIds])
-  const noFilter = numerosToponyme && filtered.length === numerosToponyme.length
-  const allNumerosSelected = noFilter && (selectedNumerosIds.length === numerosToponyme.length)
+  const noFilter = numeros && filtered.length === numeros.length
+  const allNumerosSelected = noFilter && (selectedNumerosIds.length === numeros.length)
   const allFilteredNumerosSelected = !noFilter && (filtered.length === selectedNumerosIds.length)
 
   const isAllSelected = useMemo(() => allNumerosSelected || allFilteredNumerosSelected, [allFilteredNumerosSelected, allNumerosSelected])
 
   const toEdit = useMemo(() => {
-    if (numerosToponyme && noFilter) {
+    if (numeros && noFilter) {
       return selectedNumerosIds
     }
 
     return selectedNumerosIds.map(({_id}) => _id)
-  }, [numerosToponyme, selectedNumerosIds, noFilter])
+  }, [numeros, selectedNumerosIds, noFilter])
 
   const handleSelect = id => {
     setSelectedNumerosIds(selectedNumero => {
@@ -137,8 +137,8 @@ const Toponyme = (({toponyme, defaultNumeros}) => {
 
   const onRemove = useCallback(async idNumero => {
     await removeNumero(idNumero, token)
-    reloadNumerosToponyme(toponyme._id)
-  }, [reloadNumerosToponyme, toponyme, token])
+    reloadNumerosToponyme()
+  }, [reloadNumerosToponyme, token])
 
   const onMultipleRemove = useCallback(async numeros => {
     await Promise.all(numeros.map(async numero => {
@@ -209,7 +209,7 @@ const Toponyme = (({toponyme, defaultNumeros}) => {
       {isGroupedActionsShown && (
         <GroupedActions
           idVoie={toponyme._id}
-          numeros={numerosToponyme}
+          numeros={numeros}
           selectedNumerosIds={toEdit}
           resetSelectedNumerosIds={() => setSelectedNumerosIds([])}
           setIsRemoveWarningShown={setIsRemoveWarningShown}
@@ -237,7 +237,7 @@ const Toponyme = (({toponyme, defaultNumeros}) => {
       <Pane flex={1} overflowY='scroll'>
         <Table>
           <Table.Head>
-            {!editingId && numerosToponyme && token && filtered.length > 1 && (
+            {!editingId && numeros && token && filtered.length > 1 && (
               <Table.Cell flex='0 1 1'>
                 <Checkbox
                   checked={isAllSelected}

--- a/pages/bal/voie-heading.js
+++ b/pages/bal/voie-heading.js
@@ -51,7 +51,6 @@ const VoieHeading = ({defaultVoie}) => {
     >
       {editingId === voie._id ? (
         <VoieEditor
-          hasNumeros={numeros.length > 0}
           initialValue={voie}
           isEnabledComplement={Boolean(baseLocale.enableComplement)}
           onSubmit={onEditVoie}

--- a/pages/bal/voie-heading.js
+++ b/pages/bal/voie-heading.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import {Pane, Heading, EditIcon, Text} from 'evergreen-ui'
 
 import {editVoie} from '../../lib/bal-api'
-import {getFullVoieName} from '../../lib/voie'
 
 import TokenContext from '../../contexts/token'
 import BalDataContext from '../../contexts/bal-data'
@@ -14,7 +13,7 @@ const VoieHeading = ({defaultVoie}) => {
   const [voie, setVoie] = useState(defaultVoie)
   const [hovered, setHovered] = useState(false)
   const {token} = useContext(TokenContext)
-  const {baseLocale, editingId, setEditingId, isEditing, reloadVoies, numeros} = useContext(BalDataContext)
+  const {editingId, setEditingId, isEditing, reloadVoies, numeros} = useContext(BalDataContext)
 
   const onEnableVoieEditing = useCallback(() => {
     if (!isEditing) {
@@ -23,12 +22,11 @@ const VoieHeading = ({defaultVoie}) => {
     }
   }, [setEditingId, isEditing, voie._id])
 
-  const onEditVoie = useCallback(async ({nom, typeNumerotation, trace, complement, positions}) => {
+  const onEditVoie = useCallback(async ({nom, typeNumerotation, trace, positions}) => {
     const editedVoie = await editVoie(voie._id, {
       nom,
       typeNumerotation,
       trace,
-      complement,
       positions
     }, token)
 
@@ -52,7 +50,6 @@ const VoieHeading = ({defaultVoie}) => {
       {editingId === voie._id ? (
         <VoieEditor
           initialValue={voie}
-          isEnabledComplement={Boolean(baseLocale.enableComplement)}
           onSubmit={onEditVoie}
           onCancel={() => setEditingId(null)}
         />
@@ -63,7 +60,7 @@ const VoieHeading = ({defaultVoie}) => {
           onMouseEnter={() => setHovered(true)}
           onMouseLeave={() => setHovered(false)}
         >
-          {getFullVoieName(voie, Boolean(baseLocale.enableComplement))}
+          {voie.nom}
           {!isEditing && (
             <EditIcon
               marginBottom={-2}
@@ -84,7 +81,6 @@ VoieHeading.propTypes = {
   defaultVoie: PropTypes.shape({
     _id: PropTypes.string.isRequired,
     nom: PropTypes.string.isRequired,
-    complement: PropTypes.string,
     positions: PropTypes.array.isRequired
   }).isRequired
 }

--- a/pages/bal/voie-heading.js
+++ b/pages/bal/voie-heading.js
@@ -22,12 +22,11 @@ const VoieHeading = ({defaultVoie}) => {
     }
   }, [setEditingId, isEditing, voie._id])
 
-  const onEditVoie = useCallback(async ({nom, typeNumerotation, trace, positions}) => {
+  const onEditVoie = useCallback(async ({nom, typeNumerotation, trace}) => {
     const editedVoie = await editVoie(voie._id, {
       nom,
       typeNumerotation,
-      trace,
-      positions
+      trace
     }, token)
 
     setEditingId(null)
@@ -80,8 +79,7 @@ const VoieHeading = ({defaultVoie}) => {
 VoieHeading.propTypes = {
   defaultVoie: PropTypes.shape({
     _id: PropTypes.string.isRequired,
-    nom: PropTypes.string.isRequired,
-    positions: PropTypes.array.isRequired
+    nom: PropTypes.string.isRequired
   }).isRequired
 }
 

--- a/pages/bal/voie-heading.js
+++ b/pages/bal/voie-heading.js
@@ -60,7 +60,7 @@ const VoieHeading = ({defaultVoie}) => {
           onMouseLeave={() => setHovered(false)}
         >
           {voie.nom}
-          {!isEditing && (
+          {!isEditing && token && (
             <EditIcon
               marginBottom={-2}
               marginLeft={8}

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -81,8 +81,8 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
 
   const editedNumero = filtered.find(numero => numero._id === editingId)
 
-  const onAdd = useCallback(async ({numero, toponyme, suffixe, comment, positions}) => {
-    await addNumero(voie._id, {
+  const onAdd = useCallback(async ({voie, numero, toponyme, suffixe, comment, positions}) => {
+    await addNumero(voie, {
       numero,
       suffixe,
       toponyme,
@@ -93,7 +93,7 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
     await reloadNumeros()
 
     setIsAdding(false)
-  }, [voie, reloadNumeros, token])
+  }, [reloadNumeros, token])
 
   const onEnableAdding = useCallback(() => {
     setIsAdding(true)

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -284,7 +284,7 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
                 isSelectable={!isEditing}
                 label={numero.numeroComplet}
                 secondary={numero.positions.length > 1 ? `${numero.positions.length} positions` : null}
-                toponyme={numero.toponyme}
+                toponymeId={numero.toponyme}
                 handleSelect={handleSelect}
                 isSelected={selectedNumerosIds.includes(numero._id)}
                 onEdit={onEnableEditing}

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -18,15 +18,12 @@ import GroupedActions from '../../components/grouped-actions'
 import VoieHeading from './voie-heading'
 
 const Voie = React.memo(({voie, defaultNumeros}) => {
-  const [editedVoie, setEditedVoie] = useState(voie)
   const [isEdited, setEdited] = useState(false)
   const [isAdding, setIsAdding] = useState(false)
   const [error, setError] = useState()
   const [isRemoveWarningShown, setIsRemoveWarningShown] = useState(false)
 
   const {token} = useContext(TokenContext)
-
-  const currentVoie = editedVoie || voie
 
   const {
     numeros,
@@ -171,12 +168,6 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
   }, [isEdited, setEditingId])
 
   useEffect(() => {
-    if (voie) {
-      setEditedVoie(null)
-    }
-  }, [voie])
-
-  useEffect(() => {
     setIsEditing(isAdding)
   }, [isAdding, setIsEditing])
 
@@ -195,7 +186,7 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
         <Pane>
           <Heading>Liste des numéros</Heading>
         </Pane>
-        {currentVoie.positions.length === 0 && token && (
+        {token && (
           <Pane marginLeft='auto'>
             <Button
               iconBefore={AddIcon}
@@ -239,77 +230,69 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
       )}
 
       <Pane flex={1} overflowY='scroll'>
-        {currentVoie.positions.length === 0 ? (
-          <Table>
-            <Table.Head>
-              {!editingId && numeros && token && filtered.length > 1 && (
-                <Table.Cell flex='0 1 1'>
-                  <Checkbox
-                    checked={isAllSelected}
-                    onChange={handleSelectAll}
-                  />
-                </Table.Cell>
-              )}
-              <Table.SearchHeaderCell
-                placeholder='Rechercher un numéro'
-                onChange={setFilter}
-              />
-            </Table.Head>
-            {isAdding && (
-              <Table.Row height='auto'>
-                <Table.Cell borderBottom display='block' paddingY={12} background='tint1'>
-                  <NumeroEditor
-                    initialVoie={voie}
-                    onSubmit={onAdd}
-                    onCancel={onCancel}
-                  />
-                </Table.Cell>
-              </Table.Row>
-            )}
-            {filtered.length === 0 && (
-              <Table.Row>
-                <Table.TextCell color='muted' fontStyle='italic'>
-                  Aucun numéro
-                </Table.TextCell>
-              </Table.Row>
-            )}
-            {editingId && editingId !== voie._id ? (
-              <Table.Row height='auto'>
-                <Table.Cell display='block' paddingY={12} background='tint1'>
-                  <NumeroEditor
-                    initialVoie={voie}
-                    initialValue={editedNumero}
-                    onSubmit={onEdit}
-                    onCancel={onCancel}
-                  />
-                </Table.Cell>
-              </Table.Row>
-            ) : (
-              filtered.map(numero => (
-                <TableRow
-                  {...numero}
-                  key={numero._id}
-                  id={numero._id}
-                  comment={numero.comment}
-                  isSelectable={!isEditing}
-                  label={numero.numeroComplet}
-                  secondary={numero.positions.length > 1 ? `${numero.positions.length} positions` : null}
-                  toponyme={numero.toponyme}
-                  handleSelect={handleSelect}
-                  isSelected={selectedNumerosIds.includes(numero._id)}
-                  onEdit={onEnableEditing}
-                  onRemove={onRemove}
+        <Table>
+          <Table.Head>
+            {!editingId && numeros && token && filtered.length > 1 && (
+              <Table.Cell flex='0 1 1'>
+                <Checkbox
+                  checked={isAllSelected}
+                  onChange={handleSelectAll}
                 />
-              ))
+              </Table.Cell>
             )}
-          </Table>
-        ) : (
-          <Pane padding={16}>
-            <Paragraph>
-              La voie « {currentVoie.nom} » est un toponyme et ne peut pas contenir de numéro.
-            </Paragraph>
-          </Pane>
-        )}
+            <Table.SearchHeaderCell
+              placeholder='Rechercher un numéro'
+              onChange={setFilter}
+            />
+          </Table.Head>
+          {isAdding && (
+            <Table.Row height='auto'>
+              <Table.Cell borderBottom display='block' paddingY={12} background='tint1'>
+                <NumeroEditor
+                  initialVoie={voie}
+                  onSubmit={onAdd}
+                  onCancel={onCancel}
+                />
+              </Table.Cell>
+            </Table.Row>
+          )}
+          {filtered.length === 0 && (
+            <Table.Row>
+              <Table.TextCell color='muted' fontStyle='italic'>
+                Aucun numéro
+              </Table.TextCell>
+            </Table.Row>
+          )}
+          {editingId && editingId !== voie._id ? (
+            <Table.Row height='auto'>
+              <Table.Cell display='block' paddingY={12} background='tint1'>
+                <NumeroEditor
+                  initialVoie={voie}
+                  initialValue={editedNumero}
+                  onSubmit={onEdit}
+                  onCancel={onCancel}
+                />
+              </Table.Cell>
+            </Table.Row>
+          ) : (
+            filtered.map(numero => (
+              <TableRow
+                {...numero}
+                key={numero._id}
+                id={numero._id}
+                comment={numero.comment}
+                isSelectable={!isEditing}
+                label={numero.numeroComplet}
+                secondary={numero.positions.length > 1 ? `${numero.positions.length} positions` : null}
+                toponyme={numero.toponyme}
+                handleSelect={handleSelect}
+                isSelected={selectedNumerosIds.includes(numero._id)}
+                onEdit={onEnableEditing}
+                onRemove={onRemove}
+              />
+            ))
+          )}
+        </Table>
       </Pane>
     </>
   )
@@ -330,8 +313,7 @@ Voie.getInitialProps = async ({baseLocale, commune, voie}) => {
 Voie.propTypes = {
   voie: PropTypes.shape({
     _id: PropTypes.string.isRequired,
-    nom: PropTypes.string.isRequired,
-    positions: PropTypes.array.isRequired
+    nom: PropTypes.string.isRequired
   }).isRequired,
   defaultNumeros: PropTypes.array
 }

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -37,7 +37,7 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
     setIsEditing
   } = useContext(BalDataContext)
 
-  useHelp(3)
+  useHelp(4)
   const [filtered, setFilter] = useFuse(numeros || defaultNumeros, 200, {
     keys: [
       'numeroComplet'

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -281,6 +281,7 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
                 key={numero._id}
                 id={numero._id}
                 comment={numero.comment}
+                warning={numero.positions.find(p => p.type === 'inconnue') ? 'Le type d’une position est inconnu' : null}
                 isSelectable={!isEditing}
                 label={numero.numeroComplet}
                 secondary={numero.positions.length > 1 ? `${numero.positions.length} positions` : null}

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -294,6 +294,7 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
                   isSelectable={!isEditing && !numero}
                   label={numero.numeroComplet}
                   secondary={numero.positions.length > 1 ? `${numero.positions.length} positions` : null}
+                  toponyme={numero.toponyme || null}
                   handleSelect={handleSelect}
                   isSelected={selectedNumerosIds.includes(numero._id)}
                   onEdit={onEnableEditing}

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -291,7 +291,7 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
                   key={numero._id}
                   id={numero._id}
                   comment={numero.comment}
-                  isSelectable={!isEditing && !numero}
+                  isSelectable={!isEditing}
                   label={numero.numeroComplet}
                   secondary={numero.positions.length > 1 ? `${numero.positions.length} positions` : null}
                   toponyme={numero.toponyme}

--- a/pages/bal/voie.js
+++ b/pages/bal/voie.js
@@ -85,7 +85,7 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
     await addNumero(voie._id, {
       numero,
       suffixe,
-      toponyme: toponyme || null,
+      toponyme,
       comment,
       positions
     }, token)
@@ -294,7 +294,7 @@ const Voie = React.memo(({voie, defaultNumeros}) => {
                   isSelectable={!isEditing && !numero}
                   label={numero.numeroComplet}
                   secondary={numero.positions.length > 1 ? `${numero.positions.length} positions` : null}
-                  toponyme={numero.toponyme || null}
+                  toponyme={numero.toponyme}
                   handleSelect={handleSelect}
                   isSelected={selectedNumerosIds.includes(numero._id)}
                   onEdit={onEnableEditing}

--- a/server/routes.js
+++ b/server/routes.js
@@ -13,6 +13,15 @@ module.exports = app => {
     })
   })
 
+  router.get('/bal/:balId/communes/:codeCommune/toponymes/:idToponyme', (req, res) => {
+    app.render(req, res, '/bal/toponyme', {
+      ...req.query,
+      balId: req.params.balId,
+      codeCommune: req.params.codeCommune,
+      idToponyme: req.params.idToponyme
+    })
+  })
+
   router.get('/bal/:balId/communes/:codeCommune', (req, res) => {
     app.render(req, res, '/bal/commune', {
       ...req.query,


### PR DESCRIPTION
## Contexte
Jusqu'à maintenant les voies créées à l'aide de l'éditeur pouvait disposer d'une ou plusieurs positions, les transformants visuellement en toponyme. À l'export des données, ces voies/toponymes ressortaient comme un numéro 9999. 

Il était également possible d'ajouter un complément de nom de voie servant à alimenter le champ `lieudit_complement_nom` du format BAL 1.2.

## Constat
Ce système, en plus d'être assez déroutant pour l'utilisateur, ne permet pas de gérer le simple cas des hameaux sans créer de doublon. 

## Évolution
La gestion des toponymes a été entièrement revue afin d'être plus claire pour l'utilisateur et permettre de gérer facilement les principaux "types" de toponymes.

Pour créer un toponyme qui est lui-même une adresse, il suffira de créer un toponyme et lui indiquer (ou non) une position. Il en résultera une adresse avec un numéro 9999.

Dans le cas d'un hameau par exemple, il suffira de créer toponyme et de lui assigner des numéros. Lors de l'export des données ces numéros se verront attribuer le nom du toponyme dans leur champ `lieudit_complement_nom`.

--------------

### Résumé des évolutions
- Séparation par onglet des voies et des toponymes
- Suppression des voies/toponymes
- Indication des toponymes associés aux numéros depuis leurs voies
- Assignation de numéro à un toponyme 

https://user-images.githubusercontent.com/7040549/114747881-9739ee00-9d51-11eb-8c31-0c88e9978842.mov

<img width="1423" alt="Capture d’écran 2021-04-14 à 18 34 41" src="https://user-images.githubusercontent.com/7040549/114747932-a620a080-9d51-11eb-9a29-e1608fb6c2f3.png">

<img width="499" alt="Capture d’écran 2021-04-14 à 18 49 20" src="https://user-images.githubusercontent.com/7040549/114748449-3ced5d00-9d52-11eb-9aac-c31b9655754e.png">



Attention, cette PR est liée avec : https://github.com/etalab/api-bal/pull/269
Fix #244 