### PR TITLE
Corrige les avertissements concernant les <Select> Evergreen

### DIFF
--- a/components/bal/position-editor.js
+++ b/components/bal/position-editor.js
@@ -1,6 +1,6 @@
 import React, {useContext} from 'react'
 import PropTypes from 'prop-types'
-import {Strong, Pane, SelectField, Heading, Icon, Small, TrashIcon, MapMarkerIcon, IconButton, Button, AddIcon} from 'evergreen-ui'
+import {Strong, Pane, Select, Heading, Icon, Small, TrashIcon, MapMarkerIcon, IconButton, Button, AddIcon} from 'evergreen-ui'
 
 import MarkersContext from '../../contexts/markers'
 
@@ -34,16 +34,18 @@ function PositionEditor({isToponyme}) {
 
           {markers.map(marker => (
             <>
-              <SelectField
-                defaultValue={marker.type}
+              <Select
+                value={marker.type}
                 marginBottom={8}
                 height={32}
                 onChange={e => handleChange(e, marker)}
               >
                 {positionsTypesList.map(positionType => (
-                  <option key={positionType.value} value={positionType.value} selected={marker.type === positionType.value}>{positionType.name}</option>
+                  <option key={positionType.value} value={positionType.value}>
+                    {positionType.name}
+                  </option>
                 ))}
-              </SelectField>
+              </Select>
               <Icon icon={MapMarkerIcon} size={22} margin='auto' />
               <Heading size={100} marginY='auto'>
                 <Small>{marker.latitude && marker.latitude.toFixed(6)}</Small>

--- a/components/grouped-actions.js
+++ b/components/grouped-actions.js
@@ -17,7 +17,6 @@ const GroupedActions = ({idVoie, numeros, selectedNumerosIds, resetSelectedNumer
   const [isLoading, setIsLoading] = useState(false)
   const [positionType, onPositionTypeChange] = useInput('')
   const [selectedVoieId, setSelectedVoieId] = useState(idVoie)
-  const [selectedToponymeId, setSelectedToponymeId] = useState()
   const [error, setError] = useState()
   const [comment, onCommentChange] = useInput('')
   const [removeAllComments, onRemoveAllCommentsChange] = useCheckboxInput(false)
@@ -28,6 +27,8 @@ const GroupedActions = ({idVoie, numeros, selectedNumerosIds, resetSelectedNumer
   const selectedNumerosUniqToponyme = uniq(selectedNumeros.map(numero => numero.toponyme))
   const hasUniqToponyme = selectedNumerosUniqToponyme.filter(Boolean).length === 1
   const selectedNumerosUniqVoie = uniq(selectedNumeros.map(numero => numero.voie))
+
+  const [selectedToponymeId, setSelectedToponymeId] = useState(hasUniqToponyme ? selectedNumerosUniqToponyme[0] : null)
 
   const handleComplete = () => {
     setIsShown(false)
@@ -104,6 +105,7 @@ const GroupedActions = ({idVoie, numeros, selectedNumerosIds, resetSelectedNumer
           <Paragraph marginBottom={8} color='muted'>{`${selectedNumerosIds.length} numéros sélectionnés`}</Paragraph>
 
           <SelectField
+            value={selectedVoieId}
             label='Voie'
             flex={1}
             disabled={selectedNumerosUniqVoie.length > 1}
@@ -111,11 +113,7 @@ const GroupedActions = ({idVoie, numeros, selectedNumerosIds, resetSelectedNumer
             onChange={event => setSelectedVoieId(event.target.value)}
           >
             {sortBy(voies, v => normalizeSort(v.nom)).map(({_id, nom}) => (
-              <option
-                key={_id}
-                selected={_id === selectedVoieId}
-                value={_id}
-              >
+              <option key={_id} value={_id}>
                 {nom}
               </option>
             ))}
@@ -128,6 +126,7 @@ const GroupedActions = ({idVoie, numeros, selectedNumerosIds, resetSelectedNumer
 
           <Pane display='flex'>
             <SelectField
+              value={selectedToponymeId}
               label='Toponyme'
               flex={1}
               disabled={selectedNumerosUniqToponyme.length > 1}
@@ -136,11 +135,7 @@ const GroupedActions = ({idVoie, numeros, selectedNumerosIds, resetSelectedNumer
             >
               <option value=''>{selectedToponymeId || hasUniqToponyme ? 'Ne pas associer de toponyme' : '- Choisir un toponyme -'}</option>
               {sortBy(toponymes, t => normalizeSort(t.nom)).map(({_id, nom}) => (
-                <option
-                  key={_id}
-                  value={_id}
-                  selected={_id === selectedNumerosUniqToponyme[0]}
-                >
+                <option key={_id} value={_id}>
                   {nom}
                 </option>
               ))}
@@ -152,6 +147,7 @@ const GroupedActions = ({idVoie, numeros, selectedNumerosIds, resetSelectedNumer
           )}
 
           <SelectField
+            value={positionType}
             disabled={hasMultiposition}
             flex={1}
             label='Type de position'
@@ -160,10 +156,10 @@ const GroupedActions = ({idVoie, numeros, selectedNumerosIds, resetSelectedNumer
             onChange={onPositionTypeChange}
           >
             {selectedNumerosUniqType.length !== 1 && (
-              <option selected value='' >-- Veuillez choisir un type de position --</option>
+              <option value='' >-- Veuillez choisir un type de position --</option>
             )}
             {positionsTypesList.map(positionType => (
-              <option key={positionType.value} selected={selectedNumerosUniqType.toString() === positionType.value} value={positionType.value}>{positionType.name}</option>
+              <option key={positionType.value} value={positionType.value}>{positionType.name}</option>
             ))}
           </SelectField>
 

--- a/components/toponyme/add-numeros.js
+++ b/components/toponyme/add-numeros.js
@@ -9,14 +9,14 @@ import {getNumeros} from '../../lib/bal-api'
 import BalDataContext from '../../contexts/bal-data'
 
 function AddNumeros({onSubmit, onCancel, isLoading}) {
-  const [selectedVoie, setSelectedVoie] = useState(null)
+  const [selectedVoieId, setSelectedVoieId] = useState()
   const [voieNumeros, setVoieNumeros] = useState([])
   const [selectedVoieNumeros, setSelectedVoieNumeros] = useState([])
 
   const {voies} = useContext(BalDataContext)
 
   const handleSelectVoie = async idVoie => {
-    setSelectedVoie(idVoie)
+    setSelectedVoieId(idVoie)
     if (idVoie) {
       const numeros = await getNumeros(idVoie)
       setVoieNumeros(numeros)
@@ -39,12 +39,12 @@ function AddNumeros({onSubmit, onCancel, isLoading}) {
 
     if (selectedNumeroCount === 1) {
       const numero = voieNumeros.find(({_id}) => _id === selectedVoieNumeros[0])
-      const voie = voies.find(({_id}) => _id === selectedVoie)
+      const voie = voies.find(({_id}) => _id === selectedVoieId)
       return `le ${numero.numero} ${voie.nom}`
     }
 
     return `${selectedNumeroCount} numéros sélectionnés`
-  }, [selectedVoie, voieNumeros, selectedVoieNumeros, voies])
+  }, [selectedVoieId, voieNumeros, selectedVoieNumeros, voies])
 
   const handleSubmit = useCallback(() => {
     const numeros = selectedVoieNumeros.length > 0 ?
@@ -58,50 +58,48 @@ function AddNumeros({onSubmit, onCancel, isLoading}) {
     <Pane>
       <Pane display='flex'>
         <SelectField
+          value={selectedVoieId}
           label='Voie'
           flex={1}
           marginBottom={16}
           onChange={e => handleSelectVoie(e.target.value)}
         >
-          <option value={null}>- Sélectionnez une voie -</option>
+          {!selectedVoieId && <option>- Sélectionnez une voie -</option>}
           {sortBy(voies, v => normalizeSort(v.nom)).map(({_id, nom}) => (
-            <option key={_id} value={_id} selected={_id === selectedVoie}>
+            <option key={_id} value={_id}>
               {nom}
             </option>
           ))}
         </SelectField>
       </Pane>
 
-      {selectedVoie && (
-        <>
+      {selectedVoieId && (
+        <Alert marginY={8} title='Préciser les numéros à ajouter au toponyme'>
+          <Text>
+            Sélectionnez les numéros que vous souhaitez ajouter au toponyme. Si aucun numéro n’est spécifié, alors tous les numéros de la voie seront ajoutés.
+          </Text>
 
-          <Alert marginY={8} title='Préciser les numéros à ajouter au toponyme'>
-            <Text>
-              Sélectionnez les numéros que vous souhaitez ajouter au toponyme. Si aucun numéro n’est spécifié, alors tous les numéros de la voie seront ajoutés.
-            </Text>
-
-            <Pane diplay='flex'>
-              <SelectMenu
-                isMultiSelect
-                hasFilter={false}
-                title='Sélection des numéros'
-                options={voieNumeros.map(({_id, numero, suffixe}) => ({label: `${numero}${suffixe ? suffixe : ''}`, value: _id}))}
-                selected={selectedVoieNumeros}
-                emptyView={(
-                  <Pane height='100%' paddingX='1em' display='flex' alignItems='center' justifyContent='center' textAlign='center'>
-                    <Text size={300}>Aucun numéro n’est disponible pour cette voie</Text>
-                  </Pane>
-                )}
-                onSelect={handleSelectNumero}
-                onDeselect={handleSelectNumero}
-              >
-                <Button marginTop={8} type='div'>
-                  {numerosLabel}
-                </Button>
-              </SelectMenu>
-            </Pane>
-          </Alert>
-        </>
+          <Pane diplay='flex'>
+            <SelectMenu
+              isMultiSelect
+              hasFilter={false}
+              title='Sélection des numéros'
+              options={voieNumeros.map(({_id, numero, suffixe}) => ({label: `${numero}${suffixe ? suffixe : ''}`, value: _id}))}
+              selected={selectedVoieNumeros}
+              emptyView={(
+                <Pane height='100%' paddingX='1em' display='flex' alignItems='center' justifyContent='center' textAlign='center'>
+                  <Text size={300}>Aucun numéro n’est disponible pour cette voie</Text>
+                </Pane>
+              )}
+              onSelect={handleSelectNumero}
+              onDeselect={handleSelectNumero}
+            >
+              <Button marginTop={8} type='div'>
+                {numerosLabel}
+              </Button>
+            </SelectMenu>
+          </Pane>
+        </Alert>
       )}
 
       <Button
@@ -109,7 +107,7 @@ function AddNumeros({onSubmit, onCancel, isLoading}) {
         type='submit'
         appearance='primary'
         intent='success'
-        disabled={!(selectedVoie && voieNumeros.length > 0)}
+        disabled={!(selectedVoieId && voieNumeros.length > 0)}
         marginTop={16}
         onClick={handleSubmit}
       >


### PR DESCRIPTION
## Problème
Une grande partie des `<Select />` de Evergreen renvoyé un avertissement concernant l'usage du champ `selected` dans les `options` du composant.

## Résolution
Le champ `value` est désormais défini dans le `select` et les `options` sans `defaultValue` ni `selected`. 