### PR TITLE
Amélioration UX de l’association des parcelles cadastrale

### DIFF
--- a/components/bal/address-editor.js
+++ b/components/bal/address-editor.js
@@ -212,9 +212,9 @@ function AddressEditor({onSubmit, onCancel, isToponyme, setIsToponyme}) {
         onChange={e => setIsToponyme(e.target.checked)}
       />
 
-      <PositionEditor />
+      <PositionEditor isToponyme={isToponyme} />
 
-      <SelectParcelles />
+      <SelectParcelles isToponyme={isToponyme} />
 
       {!isToponyme && (
         <Comment input={comment} onChange={onCommentChange} />

--- a/components/bal/draw-editor.js
+++ b/components/bal/draw-editor.js
@@ -31,6 +31,7 @@ const DrawEditor = ({trace}) => {
       </Heading>
 
       <Alert
+        marginTop={8}
         intent='none'
         title='Utilisez la carte pour dessiner le tracer de la voie'
       >

--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -214,17 +214,6 @@ function NumeroEditor({initialVoieId, initialValue, onSubmit, onCancel}) {
         <PositionEditor />
       )}
 
-      {alert && (
-        <Alert marginBottom={16}>
-          {initialValue && markers.length > 1 ?
-            'Déplacer les marqueurs sur la carte pour modifier les positions' :
-            initialValue && markers.length === 1 ?
-              'Déplacer le marqueur sur la carte pour déplacer le numéro.' :
-              'Déplacer le marqueur sur la carte pour placer le numéro.'
-          }
-        </Alert>
-      )}
-
       <SelectParcelles />
 
       <Comment input={comment} onChange={onCommentChange} />

--- a/components/bal/numero-editor/select-parcelles.js
+++ b/components/bal/numero-editor/select-parcelles.js
@@ -1,6 +1,6 @@
 import React, {useContext} from 'react'
 import PropTypes from 'prop-types'
-import {Pane, Button, Badge, Alert, TrashIcon, ControlIcon, Paragraph} from 'evergreen-ui'
+import {Pane, Button, Badge, Alert, TrashIcon, ControlIcon, Text} from 'evergreen-ui'
 
 import ParcellesContext from '../../../contexts/parcelles'
 
@@ -37,17 +37,24 @@ function SelectParcelles({isToponyme}) {
               </Badge>
             )
           }) : (
-            <Alert marginBottom={16}>
-              <Paragraph>
+            <Alert marginTop={8}>
+              <Text>
                 Depuis la carte, cliquez sur les parcelles que vous souhaitez ajouter au {addressType}.
-              </Paragraph>
-
-              {!showCadastre && (
-                <Button marginTop={8} iconAfter={ControlIcon} onClick={() => setShowCadastre(true)}>Afficher le cadastre</Button>
-              )}
+              </Text>
             </Alert>
           )}
       </Pane>
+
+      <Button
+        type='button'
+        display='flex'
+        justifyContent='center'
+        marginTop={8}
+        iconAfter={ControlIcon}
+        onClick={() => setShowCadastre(!showCadastre)}
+      >
+        {showCadastre ? 'Masquer' : 'Afficher'} le cadastre
+      </Button>
     </Pane>
   )
 }

--- a/components/bal/numero-editor/select-parcelles.js
+++ b/components/bal/numero-editor/select-parcelles.js
@@ -3,14 +3,16 @@ import {Pane, Label, Badge, Alert, TrashIcon} from 'evergreen-ui'
 
 import ParcellesContext from '../../../contexts/parcelles'
 
+import InputLabel from '../../input-label'
 function SelectParcelles() {
   const {selectedParcelles, hoveredParcelle, handleHoveredParcelle, handleParcelle} = useContext(ParcellesContext)
 
   return (
     <Pane display='flex' flexDirection='column' marginY='1em'>
-      <Label marginBottom={4} display='block'>
-        Parcelles cadastre
-      </Label>
+      <InputLabel
+        title='Parcelles cadastre'
+        help='Depuis la carte, cliquez sur les parcelles que vous souhaitez ajouter au numéro. En précisant les parcelles associées à cette adresse, vous accélérez sa réutilisation par de nombreux services, DDFiP, opérateurs de courrier, de fibre et de GPS.'
+      />
       <Pane>
         {selectedParcelles.length > 0 ?
           selectedParcelles.map(parcelle => {

--- a/components/bal/numero-editor/select-parcelles.js
+++ b/components/bal/numero-editor/select-parcelles.js
@@ -1,4 +1,5 @@
 import React, {useContext} from 'react'
+import PropTypes from 'prop-types'
 import {Pane, Button, Badge, Alert, TrashIcon, ControlIcon, Paragraph} from 'evergreen-ui'
 
 import ParcellesContext from '../../../contexts/parcelles'
@@ -6,15 +7,16 @@ import ParcellesContext from '../../../contexts/parcelles'
 import InputLabel from '../../input-label'
 import MapContext from '../../../contexts/map'
 
-function SelectParcelles() {
+function SelectParcelles({isToponyme}) {
   const {showCadastre, setShowCadastre} = useContext(MapContext)
   const {selectedParcelles, hoveredParcelle, handleHoveredParcelle, handleParcelle} = useContext(ParcellesContext)
+  const addressType = isToponyme ? 'toponyme' : 'numéro'
 
   return (
     <Pane display='flex' flexDirection='column' marginY='1em'>
       <InputLabel
         title='Parcelles cadastre'
-        help='Depuis la carte, cliquez sur les parcelles que vous souhaitez ajouter au numéro. En précisant les parcelles associées à cette adresse, vous accélérez sa réutilisation par de nombreux services, DDFiP, opérateurs de courrier, de fibre et de GPS.'
+        help={`Depuis la carte, cliquez sur les parcelles que vous souhaitez ajouter au ${addressType}. En précisant les parcelles associées à cette adresse, vous accélérez sa réutilisation par de nombreux services, DDFiP, opérateurs de courrier, de fibre et de GPS.`}
       />
       <Pane>
         {selectedParcelles.length > 0 ?
@@ -37,7 +39,7 @@ function SelectParcelles() {
           }) : (
             <Alert marginBottom={16}>
               <Paragraph>
-                Depuis la carte, cliquez sur les parcelles que vous souhaitez ajouter au numéro.
+                Depuis la carte, cliquez sur les parcelles que vous souhaitez ajouter au {addressType}.
               </Paragraph>
 
               {!showCadastre && (
@@ -48,6 +50,14 @@ function SelectParcelles() {
       </Pane>
     </Pane>
   )
+}
+
+SelectParcelles.defaultProps = {
+  isToponyme: false
+}
+
+SelectParcelles.propTypes = {
+  isToponyme: PropTypes.bool
 }
 
 export default SelectParcelles

--- a/components/bal/numero-editor/select-parcelles.js
+++ b/components/bal/numero-editor/select-parcelles.js
@@ -1,10 +1,13 @@
 import React, {useContext} from 'react'
-import {Pane, Label, Badge, Alert, TrashIcon} from 'evergreen-ui'
+import {Pane, Button, Badge, Alert, TrashIcon, ControlIcon, Paragraph} from 'evergreen-ui'
 
 import ParcellesContext from '../../../contexts/parcelles'
 
 import InputLabel from '../../input-label'
+import MapContext from '../../../contexts/map'
+
 function SelectParcelles() {
+  const {showCadastre, setShowCadastre} = useContext(MapContext)
   const {selectedParcelles, hoveredParcelle, handleHoveredParcelle, handleParcelle} = useContext(ParcellesContext)
 
   return (
@@ -32,14 +35,15 @@ function SelectParcelles() {
               </Badge>
             )
           }) : (
-            <>
-              <Alert marginBottom={16}>
+            <Alert marginBottom={16}>
+              <Paragraph>
                 Depuis la carte, cliquez sur les parcelles que vous souhaitez ajouter au numéro.
-              </Alert>
-              <Alert marginBottom={16}>
-                En précisant les parcelles associées à cette adresse, vous accélérez sa réutilisation par de nombreux services, DDFiP, opérateurs de courrier, de fibre et de GPS.
-              </Alert>
-            </>
+              </Paragraph>
+
+              {!showCadastre && (
+                <Button marginTop={8} iconAfter={ControlIcon} onClick={() => setShowCadastre(true)}>Afficher le cadastre</Button>
+              )}
+            </Alert>
           )}
       </Pane>
     </Pane>

--- a/components/bal/position-editor.js
+++ b/components/bal/position-editor.js
@@ -5,6 +5,7 @@ import {Strong, Pane, Select, Heading, Icon, Small, TrashIcon, MapMarkerIcon, Ic
 import MarkersContext from '../../contexts/markers'
 
 import {positionsTypesList} from '../../lib/positions-types-list'
+import InputLabel from '../input-label'
 
 function PositionEditor({isToponyme}) {
   const {markers, addMarker, updateMarker, removeMarker} = useContext(MarkersContext)
@@ -24,6 +25,16 @@ function PositionEditor({isToponyme}) {
 
   return (
     <>
+      <InputLabel
+        title='Positions'
+        help={markers.length > 1 ?
+          'Déplacer les marqueurs sur la carte pour modifier les positions' :
+          markers.length === 1 ?
+            `Déplacer le marqueur sur la carte pour déplacer le ${isToponyme ? 'toponyme' : 'numéro'}.` :
+            `Déplacer le marqueur sur la carte pour placer le ${isToponyme ? 'toponyme' : 'numéro'}.`
+        }
+      />
+
       {markers.length > 0 ? (
         <Pane display='grid' gridTemplateColumns='2fr .5fr 1fr 1fr .5fr'>
           <Strong fontWeight={400}>Type</Strong>

--- a/components/bal/toponyme-editor.js
+++ b/components/bal/toponyme-editor.js
@@ -131,15 +131,6 @@ function ToponymeEditor({initialValue, onSubmit, onCancel}) {
 
       <PositionEditor isToponyme />
 
-      {alert && (
-        <Alert marginBottom={16}>
-          {initialValue ?
-            'Déplacer le marqueur sur la carte pour déplacer le toponyme.' :
-            'Déplacer le marqueur sur la carte pour placer le toponyme.'
-          }
-        </Alert>
-      )}
-
       <SelectParcelles />
 
       {error && (

--- a/components/bal/toponyme-editor.js
+++ b/components/bal/toponyme-editor.js
@@ -131,7 +131,7 @@ function ToponymeEditor({initialValue, onSubmit, onCancel}) {
 
       <PositionEditor isToponyme />
 
-      <SelectParcelles />
+      <SelectParcelles isToponyme />
 
       {error && (
         <Alert marginBottom={16} intent='danger' title='Erreur'>

--- a/components/input-label.js
+++ b/components/input-label.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {Label, Tooltip, HelpIcon} from 'evergreen-ui'
+
+function InputLabel({title, help}) {
+  return (
+    <Label marginTop={8} marginBottom={4}>
+      {title} {help && (
+        <Tooltip content={help}>
+          <HelpIcon marginLeft={4} verticalAlign='middle' />
+        </Tooltip>
+      )}
+    </Label>
+  )
+}
+
+InputLabel.defaultProps = {
+  help: null
+}
+
+InputLabel.propTypes = {
+  title: PropTypes.string.isRequired,
+  help: PropTypes.string
+}
+
+export default InputLabel

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -74,11 +74,10 @@ function generateNewStyle(style, sources, layers) {
 
 function Map({interactive, commune, voie, toponyme}) {
   const router = useRouter()
-  const {map, setMap, style, setStyle, defaultStyle, viewport, setViewport} = useContext(MapContext)
+  const {map, setMap, style, setStyle, defaultStyle, viewport, setViewport, showCadastre, setShowCadastre} = useContext(MapContext)
   const {isParcelleSelectionEnabled, handleParcelle} = useContext(ParcellesContext)
 
   const [showNumeros, setShowNumeros] = useState(true)
-  const [showCadastre, setShowCadastre] = useState(false)
   const [openForm, setOpenForm] = useState(false)
   const [showContextMenu, setShowContextMenu] = useState(null)
   const [editPrevStyle, setEditPrevSyle] = useState(defaultStyle)

--- a/components/map/map.js
+++ b/components/map/map.js
@@ -112,7 +112,7 @@ function Map({interactive, commune, voie, toponyme}) {
   const interactiveLayerIds = useMemo(() => {
     const layers = []
 
-    if (isParcelleSelectionEnabled) {
+    if (isParcelleSelectionEnabled && showCadastre) {
       return ['parcelles-fill']
     }
 
@@ -129,7 +129,7 @@ function Map({interactive, commune, voie, toponyme}) {
     }
 
     return layers
-  }, [isParcelleSelectionEnabled, sources, voie])
+  }, [isParcelleSelectionEnabled, sources, voie, showCadastre])
 
   const onShowNumeroChange = useCallback(value => {
     setShowNumeros(value)

--- a/components/map/style-selector.js
+++ b/components/map/style-selector.js
@@ -1,8 +1,6 @@
-import React, {useState, useContext, useEffect} from 'react'
+import React, {useState} from 'react'
 import PropTypes from 'prop-types'
 import {Pane, SelectMenu, Button, Position, Tooltip, LayersIcon, ControlIcon} from 'evergreen-ui'
-
-import ParcellesContext from '../../contexts/parcelles'
 
 const STYLES = [
   {label: 'Plan OpenMapTiles', value: 'vector'},
@@ -10,24 +8,7 @@ const STYLES = [
 ]
 
 function StyleSelector({style, isFormOpen, handleStyle, showCadastre, handleCadastre}) {
-  const {isParcelleSelectionEnabled} = useContext(ParcellesContext)
-
   const [showPopover, setShowPopover] = useState(false)
-  const [resetShowCadastre, setResetShowCadastre] = useState(false)
-
-  // Show cadastre when parcelles selection is enable
-  // and resets cadastre visibility to the previous value when the selection is disabled
-  useEffect(() => {
-    if (isParcelleSelectionEnabled && !showCadastre) {
-      handleCadastre(true)
-      setResetShowCadastre(true)
-    }
-
-    if (!isParcelleSelectionEnabled && resetShowCadastre) {
-      handleCadastre(false)
-      setResetShowCadastre(false)
-    }
-  }, [showCadastre, handleCadastre, isParcelleSelectionEnabled, resetShowCadastre])
 
   return (
     <Pane

--- a/contexts/map.js
+++ b/contexts/map.js
@@ -15,6 +15,7 @@ export function MapContextProvider(props) {
   const [map, setMap] = useState()
   const [style, setStyle] = useState(defaultStyle)
   const [viewport, setViewport] = useState(defaultViewport)
+  const [showCadastre, setShowCadastre] = useState(false)
 
   useEffect(() => {
     if (!viewport) {
@@ -25,13 +26,10 @@ export function MapContextProvider(props) {
   return (
     <MapContext.Provider
       value={{
-        map,
-        setMap,
-        style,
-        setStyle,
-        defaultStyle,
-        viewport,
-        setViewport
+        map, setMap,
+        style, setStyle, defaultStyle,
+        viewport, setViewport,
+        showCadastre, setShowCadastre
       }}
       {...props}
     />


### PR DESCRIPTION
## Context
Il nous a été remonté par des utilisateurs que l'affichage forcé de la couche cadastrale lors de l'édition d'un numéro pouvait représenté une gêne important quant à la lisibilité de la carte. De plus, le nombre de message d'aide contextuel dans le formulaire sont devenu trop nombre est perturbent également la lecture du formulaire.

## Évolutions UX
- Association des parcelles à une adresse uniquement lorsque les parcelles sont affichées
- Bouton "Afficher le cadastre" directement accessible depuis le formulaire (visible seulement quand le cadastre n'est pas affiché)
-  Messages d'aide maintenant disponible au survole de l'aide d'outil "?"
- Correction des textes d'aide pour la sélection des parcelles et des positions qui font maintenant la distinction entre toponyme et numéro

![Capture d’écran 2021-06-16 à 19 25 50](https://user-images.githubusercontent.com/7040549/122265183-b9c6bf80-ced8-11eb-8c80-187066acc7e4.png)


## Évolutions technique
- La state `showCadastre` a été déplacé dans `MapContext` afin de pouvoir être accessible depuis le menu latéral
 
--------
Fix #351 
Fix #352 