### PR TITLE
Correction de l'affichage de l'alerte à la création d'une BAL déjà existante

### DIFF
--- a/components/bases-locales-list/base-locale-card.js
+++ b/components/bases-locales-list/base-locale-card.js
@@ -113,7 +113,7 @@ const BaseLocaleCard = ({baseLocale, isAdmin, initialIsOpen, onSelect, onRemove}
           {isAdmin ? (
             <Pane borderTop display='flex' justifyContent='space-between' paddingTop='1em' marginTop='1em'>
               {status === 'draft' || status === 'demo' ? (
-                <Button iconAfter={TrashIcon} intent='danger' onClick={onRemove}>Supprimer</Button>
+                <Button iconAfter={TrashIcon} intent='danger' disabled={!onRemove} onClick={onRemove}>Supprimer</Button>
               ) : (
                 <Tooltip content='Vous ne pouvez pas supprimer une BAL losrqu‘elle est prête à être publiée'>
                   <Button isActive iconAfter={TrashIcon}>Supprimer</Button>

--- a/components/bases-locales-list/base-locale-card.js
+++ b/components/bases-locales-list/base-locale-card.js
@@ -17,10 +17,10 @@ function getBadge(status) {
   }
 }
 
-const BaseLocaleCard = ({baseLocale, editable, onSelect, onRemove, initialIsOpen, hideAdmin}) => {
+const BaseLocaleCard = ({baseLocale, isAdmin, initialIsOpen, onSelect, onRemove}) => {
   const {nom, communes, status, _updated, _created, emails} = baseLocale
   const [commune, setCommune] = useState()
-  const [isOpen, setIsOpen] = useState(editable ? initialIsOpen : false)
+  const [isOpen, setIsOpen] = useState(isAdmin ? initialIsOpen : false)
   const majDate = formatDistanceToNow(new Date(_updated), {locale: fr})
   const createDate = format(new Date(_created), 'PPP', {locale: fr})
   const badge = getBadge(status)
@@ -85,7 +85,7 @@ const BaseLocaleCard = ({baseLocale, editable, onSelect, onRemove, initialIsOpen
               <Text>Créée le <Pane><b>{createDate}</b></Pane></Text>
             </Pane>
 
-            {emails && editable && (
+            {emails && isAdmin && (
               <Pane flex={1} textAlign='center' padding='8px' display='flex' flexDirection='row' justifyContent='center' margin='auto'>
                 <Text>{emails.length < 2 ? '1 Administrateur' : emails.length + ' Administrateurs'}</Text>
                 <Tooltip
@@ -103,14 +103,14 @@ const BaseLocaleCard = ({baseLocale, editable, onSelect, onRemove, initialIsOpen
                 </Tooltip>
               </Pane>
             )}
-            {!emails && editable && !hideAdmin && (
+            {isAdmin && status === 'demo' && (
               <Pane flex={1} display='flex' flexDirection='row' justifyContent='center' marginY='auto' textAlign='center'>
                 <Text><small><i>Pas d’administrateur<br /> pour les BAL de démonstration</i></small></Text>
               </Pane>
             )}
           </Pane>
 
-          {editable ? (
+          {isAdmin ? (
             <Pane borderTop display='flex' justifyContent='space-between' paddingTop='1em' marginTop='1em'>
               {status === 'draft' || status === 'demo' ? (
                 <Button iconAfter={TrashIcon} intent='danger' onClick={onRemove}>Supprimer</Button>
@@ -126,7 +126,6 @@ const BaseLocaleCard = ({baseLocale, editable, onSelect, onRemove, initialIsOpen
               <Button appearance='primary' marginRight='8px' onClick={onSelect}>Consulter</Button>
             </Pane>
           )}
-
         </>
       )}
 
@@ -135,10 +134,9 @@ const BaseLocaleCard = ({baseLocale, editable, onSelect, onRemove, initialIsOpen
 }
 
 BaseLocaleCard.defaultProps = {
-  editable: false,
+  isAdmin: false,
   onRemove: null,
-  initialIsOpen: false,
-  hideAdmin: false
+  initialIsOpen: false
 }
 
 BaseLocaleCard.propTypes = {
@@ -155,8 +153,7 @@ BaseLocaleCard.propTypes = {
     ])
   }).isRequired,
   initialIsOpen: PropTypes.bool,
-  hideAdmin: PropTypes.bool,
-  editable: PropTypes.bool,
+  isAdmin: PropTypes.bool,
   onSelect: PropTypes.func.isRequired,
   onRemove: PropTypes.func
 

--- a/components/bases-locales-list/index.js
+++ b/components/bases-locales-list/index.js
@@ -92,7 +92,7 @@ function BasesLocalesList({basesLocales, updateBasesLocales, sortBal}) {
               {sortBal(filtered).map(bal => (
                 <BaseLocaleCard
                   key={bal._id}
-                  editable
+                  isAdmin
                   baseLocale={bal}
                   initialIsOpen={basesLocales.length === 1}
                   onSelect={() => onBalSelect(bal)}

--- a/lib/bal-api/index.js
+++ b/lib/bal-api/index.js
@@ -319,6 +319,6 @@ export function getContoursCommunes() {
   return request('/stats/couverture-bal')
 }
 
-export function foundBALbyCommuneAndEmail(codeCommune, userEmail) {
+export function searchBAL(codeCommune, userEmail) {
   return request(`/bases-locales/search?codeCommune=${codeCommune}&userEmail=${userEmail}`)
 }

--- a/pages/new/alert-published-bal.js
+++ b/pages/new/alert-published-bal.js
@@ -1,22 +1,27 @@
 import React, {useState, useEffect} from 'react'
 import PropTypes from 'prop-types'
 import Router from 'next/router'
-import {Pane, Dialog, Text, Alert} from 'evergreen-ui'
+import {uniq} from 'lodash'
+import {Pane, Dialog, Alert, Paragraph, Strong} from 'evergreen-ui'
 
 import {getCommune} from '../../lib/geo-api'
 
 import BaseLocaleCard from '../../components/bases-locales-list/base-locale-card'
 
-const AlertPublishedBAL = ({isShown, onClose, onConfirm, userBALs}) => {
-  const [commune, setCommune] = useState(null)
+const AlertPublishedBAL = ({isShown, onClose, onConfirm, basesLocales}) => {
+  const [communeLabel, setCommuneLabel] = useState('cette commune')
+  const uniqCommunes = uniq(...basesLocales.map(({communes}) => communes))
 
   useEffect(() => {
     const fetchCommune = async code => {
-      setCommune(await getCommune(code))
+      const commune = await getCommune(code)
+      if (commune) {
+        setCommuneLabel(commune.nom)
+      }
     }
 
-    fetchCommune(userBALs[0].communes[0])
-  }, [userBALs])
+    fetchCommune(basesLocales[0].communes[0])
+  }, [basesLocales])
 
   const onBalSelect = bal => {
     if (bal.communes.length === 1) {
@@ -33,13 +38,12 @@ const AlertPublishedBAL = ({isShown, onClose, onConfirm, userBALs}) => {
     <>
       <Dialog
         isShown={isShown}
-        title={userBALs.length > 1 ? (
-          'Vous avez déjà des Bases Adresses Locales existantes'
+        title={uniqCommunes.length > 1 ? (
+          'Vous avez déjà des Bases Adresses Locales pour ces communes'
         ) : (
-          'Vous avez déjà publié une Base Adresse Locale pour cette commune'
+          `Vous avez déjà créé une Base Adresse Locale pour ${communeLabel}`
         )}
         width='800px'
-        intent='success'
         confirmLabel='Créer une nouvelle Base Adresse Locale'
         cancelLabel='Annuler'
         onConfirm={onConfirm}
@@ -47,42 +51,33 @@ const AlertPublishedBAL = ({isShown, onClose, onConfirm, userBALs}) => {
       >
         <Pane>
           <Alert margin='1em'>
-            {userBALs.length > 1 ? (
-              <>
-                <Text>
-                  Des Bases Adresses Locales correpondantes existent dans notre base de données.
-                </Text>
-                <br />
-                <Text>
-                  Vous pouvez reprendre votre travail sur une de ces Bases Adresses Locales en cliquant sur &quot;Gérer mes adresses&quot; ou choisir d’en créer une nouvelle.
-                </Text>
-                <br />
-                <Text>
-                  Nous vous <u>recommandons</u> toutefois de continuer l’adressage sur une de vos Bases Adresses Locales déjà existantes.
-                </Text>
-              </>
-            ) : (
-              <>
-                <Text>
-                  Une Base Adresse Locale de la commune de <b>{commune?.nom} </b>a déjà été crée.
-                </Text>
-                <br />
-                <Text>
-                  Vous pouvez reprendre votre travail sur cette Base Adresse Locale en cliquant sur &quot;Gérer mes adresses&quot; ou choisir d’en créer une nouvelle.
-                </Text>
-                <br />
-                <Text>
-                  Nous vous <u>recommandons</u> toutefois de continuer l’adressage sur la Base Adresse Locale déjà existante.
-                </Text>
-              </>
-            )}
+            <Paragraph marginTop={8}>
+              {uniqCommunes.length > 1 ? (
+                <>Il semblerait que vous ayez <Strong>déjà créé</Strong> des Bases Adresses Locales pour ces communes.</>
+              ) : (
+                <>Une Base Adresse Locale a déjà été créée pour <Strong>{communeLabel}</Strong>.</>
+              )}
+            </Paragraph>
+            <Paragraph marginTop={8}>
+              {basesLocales.length > 1 ? (
+                <>Nous vous <Strong>recommandons de continuer l’adressage</Strong> sur une de vos Bases Adresses Locales <Strong>déjà existantes</Strong> parmi la liste ci-dessous.</>
+              ) : (
+                <>Nous vous <Strong>recommandons de continuer l’adressage</Strong> sur votre Base Adresses Locales <Strong>déjà existante</Strong> ci-dessous.</>
+              )}
+            </Paragraph>
+            <Paragraph marginTop={8}>
+              Pour reprendre votre travail, {basesLocales.length > 1 && <><Strong>sélectionnez une Base Adresse Locale</Strong> puis</>} <Strong>cliquez sur &quot;Gérer&nbsp;mes&nbsp;adresses&quot;</Strong>.
+            </Paragraph>
+            <Paragraph marginTop={8}>
+              Vous pouvez toutefois cliquer sur <Strong>&quot;Créer&nbsp;une&nbsp;nouvelle&nbsp;Base&nbsp;Adresses&nbsp;Locales&quot;</Strong> si vous souhaitez <Strong>recommencer l’adressage</Strong>.
+            </Paragraph>
           </Alert>
 
-          {userBALs.map(bal => (
+          {basesLocales.map(bal => (
             <BaseLocaleCard
               key={bal._id}
               isAdmin
-              initialIsOpen={userBALs.length === 1}
+              initialIsOpen={basesLocales.length === 1}
               baseLocale={bal}
               onSelect={() => onBalSelect(bal)}
             />
@@ -96,7 +91,7 @@ const AlertPublishedBAL = ({isShown, onClose, onConfirm, userBALs}) => {
 AlertPublishedBAL.propTypes = {
   isShown: PropTypes.bool,
   onClose: PropTypes.func.isRequired,
-  userBALs: PropTypes.object.isRequired,
+  basesLocales: PropTypes.object.isRequired,
   onConfirm: PropTypes.func.isRequired
 }
 

--- a/pages/new/alert-published-bal.js
+++ b/pages/new/alert-published-bal.js
@@ -77,20 +77,16 @@ const AlertPublishedBAL = ({isShown, onClose, onConfirm, userBALs}) => {
               </>
             )}
           </Alert>
-          {userBALs.length > 0 && (
-            userBALs.map(bal => {
-              return (
-                <BaseLocaleCard
-                  key={bal._id}
-                  hideAdmin
-                  editable={userBALs.length > 0}
-                  initialIsOpen={userBALs.length === 1}
-                  baseLocale={bal}
-                  onSelect={() => onBalSelect(bal)}
-                />
-              )
-            })
-          )}
+
+          {userBALs.map(bal => (
+            <BaseLocaleCard
+              key={bal._id}
+              isAdmin
+              initialIsOpen={userBALs.length === 1}
+              baseLocale={bal}
+              onSelect={() => onBalSelect(bal)}
+            />
+          ))}
         </Pane>
       </Dialog>
     </>

--- a/pages/new/create-form.js
+++ b/pages/new/create-form.js
@@ -4,7 +4,7 @@ import Router from 'next/router'
 import {Pane, TextInputField, Checkbox, Button, PlusIcon} from 'evergreen-ui'
 
 import {storeBalAccess} from '../../lib/tokens'
-import {createBaseLocale, addCommune, populateCommune, foundBALbyCommuneAndEmail} from '../../lib/bal-api'
+import {createBaseLocale, addCommune, populateCommune, searchBAL} from '../../lib/bal-api'
 
 import useFocus from '../../hooks/focus'
 import {useInput, useCheckboxInput} from '../../hooks/input'
@@ -55,7 +55,7 @@ function CreateForm({defaultCommune}) {
     e.preventDefault()
     setIsLoading(true)
 
-    const foundUserBALs = await foundBALbyCommuneAndEmail(commune, email)
+    const foundUserBALs = await searchBAL(commune, email)
 
     if (foundUserBALs.length > 0) {
       setUserBALs(foundUserBALs)

--- a/pages/new/create-form.js
+++ b/pages/new/create-form.js
@@ -55,10 +55,10 @@ function CreateForm({defaultCommune}) {
     e.preventDefault()
     setIsLoading(true)
 
-    const foundUserBALs = await searchBAL(commune, email)
+    const userBALs = await searchBAL(commune, email)
 
-    if (foundUserBALs.length > 0) {
-      setUserBALs(foundUserBALs)
+    if (userBALs.length > 0) {
+      setUserBALs(userBALs)
       setIsShown(true)
     } else {
       createNewBal()

--- a/pages/new/create-form.js
+++ b/pages/new/create-form.js
@@ -21,7 +21,7 @@ function CreateForm({defaultCommune}) {
   const [populate, onPopulateChange] = useCheckboxInput(true)
   const [commune, setCommune] = useState(defaultCommune ? defaultCommune.code : null)
   const [isShown, setIsShown] = useState(false)
-  const [userBALs, setUserBALs] = useState(null)
+  const [userBALs, setUserBALs] = useState([])
   const focusRef = useFocus()
 
   const onSelect = useCallback(commune => {
@@ -72,10 +72,10 @@ function CreateForm({defaultCommune}) {
 
   return (
     <Pane is='form' margin={16} padding={16} overflowY='scroll' background='white' onSubmit={onSubmit}>
-      {userBALs?.length > 0 && (
+      {userBALs.length > 0 && (
         <AlertPublishedBAL
           isShown={isShown}
-          userBALs={userBALs}
+          basesLocales={userBALs}
           onConfirm={createNewBal}
           onClose={() => onCancel()}
         />

--- a/pages/new/upload-form.js
+++ b/pages/new/upload-form.js
@@ -90,9 +90,9 @@ function UploadForm() {
       const userBALs = []
 
       await Promise.all(codes.map(async code => {
-        const foundUserBALs = await searchBAL(code, email)
-        if (foundUserBALs.length > 0) {
-          userBALs.push(...foundUserBALs)
+        const basesLocales = await searchBAL(code, email)
+        if (basesLocales.length > 0) {
+          userBALs.push(...basesLocales)
         }
       }))
 

--- a/pages/new/upload-form.js
+++ b/pages/new/upload-form.js
@@ -38,7 +38,7 @@ function UploadForm() {
   const [nom, onNomChange] = useInput('')
   const [email, onEmailChange] = useInput('')
   const focusRef = useFocus()
-  const [userBALs, setUserBALs] = useState(null)
+  const [userBALs, setUserBALs] = useState([])
   const [isShown, setIsShown] = useState(false)
 
   const onError = error => {
@@ -135,10 +135,10 @@ function UploadForm() {
   return (
     <>
       <Pane is='form' margin={16} padding={16} flex={1} overflowY='scroll' backgroundColor='white' onSubmit={onSubmit}>
-        {userBALs?.length > 0 && (
+        {userBALs.length > 0 && (
           <AlertPublishedBAL
             isShown={isShown}
-            userBALs={userBALs}
+            basesLocales={userBALs}
             onConfirm={createNewBal}
             onClose={() => onCancel()}
           />

--- a/pages/new/upload-form.js
+++ b/pages/new/upload-form.js
@@ -4,7 +4,7 @@ import {validate} from '@etalab/bal'
 import {uniq, uniqBy} from 'lodash'
 import {Pane, Alert, Button, TextInputField, Text, FormField, PlusIcon, InboxIcon} from 'evergreen-ui'
 
-import {createBaseLocale, uploadBaseLocaleCsv, foundBALbyCommuneAndEmail} from '../../lib/bal-api'
+import {createBaseLocale, uploadBaseLocaleCsv, searchBAL} from '../../lib/bal-api'
 import {storeBalAccess} from '../../lib/tokens'
 
 import useFocus from '../../hooks/focus'
@@ -90,7 +90,7 @@ function UploadForm() {
       const userBALs = []
 
       await Promise.all(codes.map(async code => {
-        const foundUserBALs = await foundBALbyCommuneAndEmail(code, email)
+        const foundUserBALs = await searchBAL(code, email)
         if (foundUserBALs.length > 0) {
           userBALs.push(...foundUserBALs)
         }


### PR DESCRIPTION
## Contexte
Cette PR vient apporter des modifications et des corrections suite à #349 

## Modifications et corrections
- Simplification de la gestion des BAL appartenant à l'utilisateur dans le composant `<BaseLocalCard />`
- Renommage de différentes variables et fonction
- Reprise du wording
- Désactive la suppression de BAL lorsque `onRemove` n'est pas défini

<img width="824" alt="Capture d’écran 2021-06-29 à 17 27 12" src="https://user-images.githubusercontent.com/7040549/123825525-445ae600-d8ff-11eb-9c72-1d4433acad32.png">

