### PR TITLE
[WIP] Assistance aux caractères accentués 

### DIFF
--- a/components/accent-tool.js
+++ b/components/accent-tool.js
@@ -1,0 +1,69 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {Popover, Button, Pane} from 'evergreen-ui'
+
+const ACCENTS = [
+  'à',
+  'â',
+  'é',
+  'è',
+  'ê',
+  'ë',
+  'î',
+  'ï',
+  'ô',
+  'ö',
+  'ù',
+  'û',
+  'ü',
+  'ç',
+  'œ',
+  'À',
+  'Â',
+  'É',
+  'È',
+  'Ê',
+  'Ë',
+  'Î',
+  'Ï',
+  'Ô',
+  'Ö',
+  'Ù',
+  'Û',
+  'Ü',
+  'Ç',
+  'Œ'
+]
+
+function AccentTool({input, handleAccent}) {
+  const handleClick = event => {
+    event.target.value = `${input}${event.target.value}`
+    handleAccent(event)
+  }
+
+  return (
+    <Popover
+      trigger='hover'
+      content={
+        <Pane width={250} height={242}>
+          <Pane display='grid' gridTemplateColumns='repeat(auto-fit, minmax(34px, auto))' gridGap={10}>
+            {ACCENTS.map(accent => (
+              <Button key={accent} appearance='minimal' value={accent} onClick={handleClick}>
+                {accent}
+              </Button>
+            ))}
+          </Pane>
+        </Pane>
+      }
+    >
+      <Button type='button'>É</Button>
+    </Popover>
+  )
+}
+
+AccentTool.propTypes = {
+  input: PropTypes.string.isRequired,
+  handleAccent: PropTypes.func.isRequired
+}
+
+export default AccentTool

--- a/components/bal/toponyme-editor.js
+++ b/components/bal/toponyme-editor.js
@@ -10,6 +10,8 @@ import {useInput} from '../../hooks/input'
 import useFocus from '../../hooks/focus'
 import useKeyEvent from '../../hooks/key-event'
 
+import AccentTool from '../accent-tool'
+
 import PositionEditor from './position-editor'
 import SelectParcelles from './numero-editor/select-parcelles'
 
@@ -114,20 +116,26 @@ function ToponymeEditor({initialValue, onSubmit, onCancel}) {
 
   return (
     <Pane is='form' onSubmit={onFormSubmit}>
-      <TextInputField
-        ref={setRef}
-        required
-        label='Nom du toponyme'
-        display='block'
-        disabled={isLoading}
-        width='100%'
-        maxWidth={500}
-        value={nom}
-        maxLength={200}
-        marginBottom={16}
-        placeholder='Nom du toponyme…'
-        onChange={onNomChange}
-      />
+      <Pane display='flex' flexDirection='row' alignItems='center'>
+        <TextInputField
+          ref={setRef}
+          required
+          label='Nom du toponyme'
+          display='block'
+          disabled={isLoading}
+          width='100%'
+          maxWidth={500}
+          value={nom}
+          maxLength={200}
+          marginBottom={16}
+          placeholder='Nom du toponyme…'
+          onChange={onNomChange}
+        />
+
+        <Pane marginTop={10} marginLeft={4}>
+          <AccentTool input={nom} handleAccent={onNomChange} />
+        </Pane>
+      </Pane>
 
       <PositionEditor isToponyme />
 

--- a/components/bal/voie-editor.js
+++ b/components/bal/voie-editor.js
@@ -9,6 +9,8 @@ import {useInput, useCheckboxInput} from '../../hooks/input'
 import useFocus from '../../hooks/focus'
 import useKeyEvent from '../../hooks/key-event'
 
+import AccentTool from '../accent-tool'
+
 import DrawEditor from './draw-editor'
 
 function VoieEditor({initialValue, onSubmit, onCancel}) {
@@ -84,20 +86,26 @@ function VoieEditor({initialValue, onSubmit, onCancel}) {
 
   return (
     <Pane is='form' onSubmit={onFormSubmit}>
-      <TextInputField
-        ref={setRef}
-        required
-        label='Nom de la voie'
-        display='block'
-        disabled={isLoading}
-        width='100%'
-        maxWidth={500}
-        value={nom}
-        maxLength={200}
-        marginBottom={16}
-        placeholder='Nom de la voie…'
-        onChange={onNomChange}
-      />
+      <Pane display='flex' flexDirection='row' alignItems='center'>
+        <TextInputField
+          ref={setRef}
+          required
+          label='Nom de la voie'
+          display='block'
+          disabled={isLoading}
+          width='100%'
+          maxWidth={500}
+          value={nom}
+          maxLength={200}
+          marginBottom={16}
+          placeholder='Nom de la voie…'
+          onChange={onNomChange}
+        />
+
+        <Pane marginTop={10} marginLeft={4}>
+          <AccentTool input={nom} handleAccent={onNomChange} />
+        </Pane>
+      </Pane>
 
       <Checkbox
         checked={isMetric}


### PR DESCRIPTION
## Contexte
Il arrive fréquemment que des noms de voie où de toponyme soit écrit sans accent. Bien souvent parce que les utilisateurs ne savent pas comment faire ces caractères accentués sur leur clavier.

## Solution
Proposer lors de l'édition du nom d'une voie ou d'un toponyme, une fenêtre offrant un raccourci aux caractères accentués les plus utilisés en français.
![Capture d’écran 2021-07-20 à 11 34 44](https://user-images.githubusercontent.com/7040549/126300095-0ea0aea2-c999-44cc-a7cc-3fb6764131cc.png)

⚠️ WORK IN PROGRESS ⚠️
Avant de valider cette PR, il est encore nécessaire d'ajouter cet assistant lors de la création d'un toponyme depuis la carte.