### PR TITLE
Corrige la suppression de BAL depuis l'alerte de doublon

### DIFF
--- a/components/bases-locales-list/base-locale-card.js
+++ b/components/bases-locales-list/base-locale-card.js
@@ -128,7 +128,7 @@ const BaseLocaleCard = ({baseLocale, isAdmin, userEmail, initialIsOpen, onSelect
           {isAdmin ? (
             <Pane borderTop display='flex' justifyContent='space-between' paddingTop='1em' marginTop='1em'>
               {status === 'draft' || status === 'demo' ? (
-                <Button iconAfter={TrashIcon} intent='danger' disabled={!onRemove} onClick={onRemove}>Supprimer</Button>
+                <Button iconAfter={TrashIcon} intent='danger' disabled={!onRemove || !hasToken} onClick={onRemove}>Supprimer</Button>
               ) : (
                 <Tooltip content='Vous ne pouvez pas supprimer une BAL losrqu‘elle est prête à être publiée'>
                   <Button isActive iconAfter={TrashIcon}>Supprimer</Button>


### PR DESCRIPTION
Désactive le bouton "Supprimer" depuis la popup d'avertissement de doublon d'une BAL si l'utilisateur ne dispose pas de son token d'administration.

Le problème avait été signalé [ici](https://github.com/etalab/editeur-bal/pull/365#issuecomment-875441900) mais a oublié d'être traité.