### PR TITLE
Empêche le dépôt d'un fichier CSV comportant plusieurs communes

### DIFF
--- a/components/uploader.js
+++ b/components/uploader.js
@@ -3,9 +3,11 @@ import PropTypes from 'prop-types'
 import {useDropzone} from 'react-dropzone'
 import {Pane, Spinner, Paragraph} from 'evergreen-ui'
 
-function Uploader({file, placeholder, onDrop, height, disabled, loading, loadingLabel, ...props}) {
+function Uploader({file, maxSize, placeholder, onDrop, onDropRejected, height, disabled, loading, loadingLabel, ...props}) {
   const {getRootProps, getInputProps, isDragActive} = useDropzone({
+    maxSize,
     onDrop,
+    onDropRejected,
     disabled,
     multiple: false
   })
@@ -53,8 +55,10 @@ function Uploader({file, placeholder, onDrop, height, disabled, loading, loading
 
 Uploader.propTypes = {
   file: PropTypes.object,
+  maxSize: PropTypes.number,
   placeholder: PropTypes.string.isRequired,
   onDrop: PropTypes.func.isRequired,
+  onDropRejected: PropTypes.func.isRequired,
   height: PropTypes.number,
   loading: PropTypes.bool,
   disabled: PropTypes.bool,
@@ -63,6 +67,7 @@ Uploader.propTypes = {
 
 Uploader.defaultProps = {
   file: null,
+  maxSize: null,
   height: 100,
   loading: false,
   disabled: false,

--- a/pages/new/upload-form.js
+++ b/pages/new/upload-form.js
@@ -108,6 +108,11 @@ function UploadForm() {
 
     if (validateResponse) {
       const codes = extractCodeCommuneFromCSV(validateResponse)
+      if (codes.length > 1) {
+        onError('Le fichier comporte plusieurs communes. Pour gérer plusieurs communes, vous devez créer plusieurs Bases Adresses Locales. L’import d’un fichier CSV n’est possible que si ce fichier ne contient les adresses que d’une commune.')
+        return
+      }
+
       const userBALs = []
 
       await Promise.all(codes.map(async code => {

--- a/pages/new/upload-form.js
+++ b/pages/new/upload-form.js
@@ -17,6 +17,8 @@ import Uploader from '../../components/uploader'
 
 import AlertPublishedBAL from './alert-published-bal'
 
+const MAX_SIZE = 10 * 1024 * 1024
+
 function getFileExtension(name) {
   const pos = name.lastIndexOf('.')
   if (pos > 0) {
@@ -53,17 +55,27 @@ function UploadForm() {
   }
 
   const onDrop = useCallback(async ([file]) => {
-    if (getFileExtension(file.name).toLowerCase() !== 'csv') {
-      return onError('Ce type de fichier n’est pas supporté. Vous devez déposer un fichier CSV.')
-    }
+    if (file) {
+      if (getFileExtension(file.name).toLowerCase() !== 'csv') {
+        return onError('Ce type de fichier n’est pas supporté. Vous devez déposer un fichier CSV.')
+      }
 
-    if (file.size > 10 * 1024 * 1024) {
-      return onError('Ce fichier est trop volumineux. Vous devez déposer un fichier de moins de 10 Mo.')
+      setFile(file)
+      setError(null)
     }
-
-    setFile(file)
-    setError(null)
   }, [])
+
+  const onDropRejected = rejectedFiles => {
+    const [file] = rejectedFiles
+
+    if (rejectedFiles.length > 1) {
+      onError('Vous ne pouvez déposer qu’un seul fichier.')
+    } else if (file.size > MAX_SIZE) {
+      return onError('Ce fichier est trop volumineux. Vous devez déposer un fichier de moins de 10 Mo.')
+    } else {
+      onError('Impossible de déposer ce fichier')
+    }
+  }
 
   const createNewBal = useCallback(async () => {
     if (!bal) {
@@ -188,12 +200,14 @@ function UploadForm() {
             <FormField label='Fichier CSV' />
             <Uploader
               file={file}
+              maxSize={MAX_SIZE}
               height={150}
               marginBottom={24}
-              placeholder='Sélectionnez ou glissez ici votre fichier BAL au format CSV (maximum 100 Mo)'
+              placeholder='Sélectionnez ou glissez ici votre fichier BAL au format CSV (maximum 10 Mo)'
               loadingLabel='Analyse en cours'
               disabled={isLoading}
               onDrop={onDrop}
+              onDropRejected={onDropRejected}
             />
           </Pane>
         </Pane>


### PR DESCRIPTION
## Description
Cette PR permet d'empêcher le dépôt de fichier CSV comportant plusieurs communes. Ceci afin de limiter la création de BAL multi-communales qui ne seront bientôt plus supportées par l'outil.

### Message d'erreur
![Capture d’écran 2021-08-24 à 11 56 53](https://user-images.githubusercontent.com/7040549/130597265-7f2616a6-830b-4218-b4c7-51c8334defd3.png)

Fix #378 

---

### Amélioration de la gestion des erreurs
- Fichier trop volumineux
- Fichiers multiple