### PR TITLE
Désactive l'ajout de commune à une BAL existante

### DIFF
--- a/components/help/help-tabs/base-locale.js
+++ b/components/help/help-tabs/base-locale.js
@@ -29,7 +29,7 @@ const BaseLocale = () => {
           Sur la page <b>Nouvelle Base Adresse Locale</b>, sélectionnez l’onglet <Tablist><Tab isSelected>Importer un fichier CSV</Tab></Tablist>
         </Paragraph>
         <OrderedList margin={8}>
-          <ListItem>Sélectionnez ou déposez votre fichier au format <b>csv</b>. Attention ce fichier ne doit pas dépasser 100 Mo.</ListItem>
+          <ListItem>Sélectionnez ou déposez votre fichier au format <b>csv</b>. Attention ce fichier ne doit pas dépasser 10 Mo.</ListItem>
           <ListItem>Indiquez le nom de votre Base Adresse Locale dans le champ <Strong size={500} fontStyle='italic'>Nom</Strong>. Il vous permettra de pouvoir identifier votre Base Adresse Locale.</ListItem>
           <ListItem>Indiquez l’adresse email de votre mairie ou de l’administrateur de la Base Adresse Locale. C’est cette adresse qui recevra le lien permettant d’accèder à l’édition de votre Base Adresse Locale.</ListItem>
           <ListItem>Pour terminer, cliquez sur le bouton <Button marginX={4} appearance='primary' intent='success' iconAfter={PlusIcon}>Créer la Base Adresse Locale</Button></ListItem>

--- a/components/help/help-tabs/communes.js
+++ b/components/help/help-tabs/communes.js
@@ -27,6 +27,12 @@ const Communes = () => {
           <ListItem>Si vous souhaitez partir de zéro, décochez la case <Strong size={500} fontStyle='italic'>Importer les voies et numéros depuis la BAN</Strong>.</ListItem>
           <ListItem>Pour terminer, cliquez sur le bouton <Button marginX={4} appearance='primary' intent='success'>Ajouter</Button></ListItem>
         </OrderedList>
+
+        <Tuto title='Bon à savoir'>
+          <ListItem listStyleType='none'>
+            L’éditeur « Mes Adresses » permet la gestion d’une Base Adresse Locale à l’échelle communale. Pour gérer plusieurs communes, vous devez créer plusieurs Bases Adresses Locales. L’ajout d’une commune n’est possible que si aucune commune n’est renseignée.
+          </ListItem>
+        </Tuto>
       </Tuto>
 
       <Tuto title='Consulter une commune'>

--- a/pages/bal/index.js
+++ b/pages/bal/index.js
@@ -2,7 +2,7 @@ import React, {useState, useCallback, useContext} from 'react'
 import PropTypes from 'prop-types'
 import Router from 'next/router'
 import {sortBy} from 'lodash'
-import {Pane, Heading, Paragraph, Button, Table, Text, AddIcon} from 'evergreen-ui'
+import {Pane, Heading, Paragraph, Button, Table, Text, AddIcon, Alert} from 'evergreen-ui'
 
 import {addCommune, removeCommune, populateCommune} from '../../lib/bal-api'
 import {getCommune} from '../../lib/geo-api'
@@ -100,7 +100,7 @@ const Index = React.memo(({baseLocale, defaultCommunes}) => {
         <Pane>
           <Heading>Liste des communes</Heading>
         </Pane>
-        {token && (
+        {token && communes.length === 0 && (
           <Pane marginLeft='auto'>
             <Button
               iconBefore={AddIcon}
@@ -114,6 +114,17 @@ const Index = React.memo(({baseLocale, defaultCommunes}) => {
           </Pane>
         )}
       </Pane>
+
+      {communes.length > 1 && (
+        <Pane padding={16}>
+          <Alert
+            intent='warning'
+            title='Gestion de plusieurs communes'
+          >
+            L’éditeur « Mes Adresses » permet la gestion d’une Base Adresse Locale à l’échelle communale. Pour gérer plusieurs communes, vous devez créer plusieurs Bases Adresses Locales.
+          </Alert>
+        </Pane>
+      )}
 
       <Pane flex={1} overflowY='scroll'>
         <Table>


### PR DESCRIPTION
## Contexte
La gestion des BAL multi-communales étant bientôt obsolète, cette PR complète #379 en empêchant également l'ajout d'une commune à une BAL existante.

Ces modifications ont pour objectifs de préparer la migration vers la gestion de Bases Adresses Locales Communale.

## Évolution
- Bouton "Ajouter une commune" supprimé lorsque la BAL possède plusieurs communes
- Affiche d'un message d'avertissement pour les BAL avec plusieurs communes
- Mise à jour de la documentation

https://user-images.githubusercontent.com/7040549/130641708-211492a2-755b-4dbf-9459-835e0efdca8b.mov

