### PR TITLE
Corrige le chargement des BAL de l'utilisateur

### DIFF
--- a/components/user-bases-locales.js
+++ b/components/user-bases-locales.js
@@ -20,7 +20,7 @@ function UserBasesLocales() {
     const basesLocales = await Promise.all(
       map(balAccess, async (token, id) => {
         try {
-          return getBaseLocale(id, token)
+          return await getBaseLocale(id, token)
         } catch (error) {
           console.log(`Impossible de récupérer la bal ${id}`)
         }
@@ -75,3 +75,4 @@ function UserBasesLocales() {
 }
 
 export default UserBasesLocales
+


### PR DESCRIPTION
## Contexte
Des utilisateurs ont remontés que la page d'accueil charger indéfiniment. Ce problème vient du fait qu'au moins une de leur BAL renvoi une erreur 404. Cette erreur est mal récupéré et empêche le changement d'affichage de l'interface.

## Solution
Cette PR corrige la récupération de l'erreur 404 afin de supprimer le chargement afficher à l'utilisateur. 
La promesse étant en réalité résolu dans le `Promise.all` et non dans le `try/catch`, il suffit de forcer la résolution de la promesse dans le `map`.