### PR TITLE
Correction de la position de l'icône de certification sous Safari

### DIFF
--- a/components/map/numero-marker.js
+++ b/components/map/numero-marker.js
@@ -99,7 +99,7 @@ function NumeroMarker({numero, colorSeed, showLabel, showContextMenu, setShowCon
 
         {numero.certifie && (
           <Tooltip content='Cette adresse est certifiée par la commune' position={Position.RIGHT}>
-            <EndorsedIcon color='success' size={13} marginX={4} style={{verticalAlign: 'text-top'}} />
+            <EndorsedIcon color='success' size={13} marginX={4} marginBottom={2} style={{verticalAlign: 'middle'}} />
           </Tooltip>
         )}
       </Pane>


### PR DESCRIPTION
## Avant
![Capture d’écran 2021-09-06 à 18 13 58](https://user-images.githubusercontent.com/7040549/132243589-2a1522a0-9752-446e-aba2-c60c7fa4cb34.png)

## Après
![Capture d’écran 2021-09-06 à 18 13 18](https://user-images.githubusercontent.com/7040549/132243587-7e89e29c-5351-4d2e-bf6b-03559b6909d2.png)

