### PR TITLE
Corrige le problème d’affichage du numéro zéro

### DIFF
--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -153,8 +153,8 @@ function NumeroEditor({initialVoieId, initialValue, onSubmit, onCancel}) {
           label='Toponyme'
           flex={1}
           marginBottom={16}
-          value={toponymeId || undefined}
-          onChange={({target}) => setToponymeId(target.value === REMOVE_TOPONYME_LABEL ? null : target.value)}
+          value={toponymeId || ''}
+          onChange={({target}) => setToponymeId(target.value === (REMOVE_TOPONYME_LABEL || '') ? null : target.value)}
         >
           <option value={null}>{initialValue?.toponyme ? REMOVE_TOPONYME_LABEL : '- Choisir un toponyme -'}</option>
           {sortBy(toponymes, t => normalizeSort(t.nom)).map(({_id, nom}) => (

--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -153,7 +153,7 @@ function NumeroEditor({initialVoieId, initialValue, onSubmit, onCancel}) {
           label='Toponyme'
           flex={1}
           marginBottom={16}
-          value={toponymeId}
+          value={toponymeId || undefined}
           onChange={({target}) => setToponymeId(target.value === REMOVE_TOPONYME_LABEL ? null : target.value)}
         >
           <option value={null}>{initialValue?.toponyme ? REMOVE_TOPONYME_LABEL : '- Choisir un toponyme -'}</option>

--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -29,7 +29,7 @@ function NumeroEditor({initialVoieId, initialValue, onSubmit, onCancel}) {
   const [toponymeId, setToponymeId] = useState(initialValue?.toponyme)
   const [isLoading, setIsLoading] = useState(false)
   const [certifie, setCertifie] = useState(initialValue?.certifie || false)
-  const [numero, onNumeroChange, resetNumero] = useInput(initialValue?.numero || '')
+  const [numero, onNumeroChange, resetNumero] = useInput(initialValue?.numero.toString() || '')
   const [nomVoie, onNomVoieChange] = useState('')
   const [suffixe, onSuffixeChange, resetSuffixe] = useInput(initialValue?.suffixe || '')
   const [comment, onCommentChange, resetComment] = useInput(initialValue?.comment || '')


### PR DESCRIPTION
Cette PR propose de transformer le type de la valeur du champ `numero` en chaine de caractère pour éviter qu'il soit considéré comme un booléen.

Elle corrige ensuite un avertissement des outils de développement par rapport à un champ du formulaire qui ne peut être `null`.

Fix #395 
