### PR TITLE
Cache les messages à destinations de l'édition en mode consultation

### DIFF
--- a/components/certification-message.js
+++ b/components/certification-message.js
@@ -4,6 +4,7 @@ import {Pane, Menu, CogIcon, Dialog, Paragraph, Strong} from 'evergreen-ui'
 
 import LocalStorageContext from '../contexts/local-storage'
 import BalDataContext from '../contexts/bal-data'
+import TokenContext from '../contexts/token'
 
 import {getCommune} from '../lib/bal-api'
 
@@ -12,6 +13,7 @@ const CertificationMessage = ({balId, codeCommune}) => {
 
   const {getInformedAboutCertification, addInformedAboutCertification} = useContext(LocalStorageContext)
   const {certifyAllNumeros} = useContext(BalDataContext)
+  const {token} = useContext(TokenContext)
 
   const handleConfirmation = async certifAuto => {
     if (certifAuto) {
@@ -42,7 +44,7 @@ const CertificationMessage = ({balId, codeCommune}) => {
 
   return (
     <Dialog
-      isShown={isShown}
+      isShown={isShown && token}
       width={800}
       intent='success'
       title='Nouvelle fonctionnalité de certification'

--- a/components/welcome-message.js
+++ b/components/welcome-message.js
@@ -1,9 +1,11 @@
 import React, {useState, useEffect, useContext} from 'react'
 import {Pane, Dialog, Alert, Link, Paragraph, Heading, Strong, HelpIcon} from 'evergreen-ui'
 
+import TokenContext from '../contexts/token'
 import LocalStorageContext from '../contexts/local-storage'
 
 function WelcomeMessage() {
+  const {token} = useContext(TokenContext)
   const {wasWelcomed, setWasWelcomed} = useContext(LocalStorageContext)
   const [isShown, setIsShown] = useState(false)
 
@@ -13,7 +15,7 @@ function WelcomeMessage() {
 
   return (
     <Dialog
-      isShown={isShown}
+      isShown={isShown && token}
       intent='success'
       title=' Bienvenue sur votre Base Adresse Locale'
       confirmLabel='Commencer l’adressage'


### PR DESCRIPTION
## Contexte
Les messages de bienvenu et de certification automatique s'affiche en mode consultation.

## Évolutions
Ces messages ne s'affiche désormais que si l'utilisateur dispose d'un `token`.