### PR TITLE
Masque les commentaires des numéros en mode consultation

### DIFF
--- a/contexts/bal-data.js
+++ b/contexts/bal-data.js
@@ -62,28 +62,28 @@ export const BalDataContextProvider = React.memo(({balId, codeCommune, idVoie, i
 
     if (id) {
       const voie = await getVoie(id)
-      const numeros = await getNumeros(id)
+      const numeros = await getNumeros(id, token)
       setVoie(voie)
       setNumeros(numeros)
     } else {
       setVoie(null)
       setNumeros(null)
     }
-  }, [idVoie])
+  }, [idVoie, token])
 
   const reloadNumerosToponyme = useCallback(async _idEdited => {
     const id = _idEdited || idToponyme
 
     if (id) {
       const toponyme = await getToponyme(id)
-      const numeros = await getNumerosToponyme(id)
+      const numeros = await getNumerosToponyme(id, token)
       setToponyme(toponyme)
       setNumeros(numeros)
     } else {
       setToponyme(null)
       setNumeros(null)
     }
-  }, [idToponyme])
+  }, [idToponyme, token])
 
   const reloadBaseLocale = useCallback(async () => {
     if (balId) {

--- a/lib/bal-api/index.js
+++ b/lib/bal-api/index.js
@@ -257,12 +257,20 @@ export function removeToponyme(idToponyme, token) {
   })
 }
 
-export function getNumerosToponyme(idToponyme) {
-  return request(`/toponymes/${idToponyme}/numeros`)
+export function getNumerosToponyme(idToponyme, token) {
+  const headers = token ? {
+    authorization: `Token ${token}`
+  } : {}
+
+  return request(`/toponymes/${idToponyme}/numeros`, {headers})
 }
 
-export function getNumeros(idVoie) {
-  return request(`/voies/${idVoie}/numeros`)
+export function getNumeros(idVoie, token) {
+  const headers = token ? {
+    authorization: `Token ${token}`
+  } : {}
+
+  return request(`/voies/${idVoie}/numeros`, {headers})
 }
 
 export function addNumero(idVoie, body, token) {


### PR DESCRIPTION
### Cette PR propose de masquer les numéros en mode consultation.

⚠️ **Cette PR a besoin de cette [Pull Request](https://github.com/etalab/api-bal/pull/297) pour fonctionner.** ⚠️

Certains utilisateurs stockent des informations sensibles dans les commentaires de leur Base Adresse Locale.
Les Bases Adresses Locales étant accessibles publiquement sans autorisation spéciale, il est préférable d'afficher les commentaires uniquement aux utilisateurs de la Base Adresse Locale disposant du jeton d'administration.

Fix #394

