### PR TITLE
Corrige le message d'erreur de la propriété `isCertified` non définie

### DIFF
--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -214,7 +214,7 @@ function NumeroEditor({initialVoieId, initialValue, onSubmit, onCancel}) {
       )}
 
       <CertificationButton
-        isCertified={initialValue?.certifie}
+        isCertified={initialValue?.certifie || false}
         isLoading={isLoading}
         onConfirm={setCertifie}
         onCancel={onFormCancel}


### PR DESCRIPTION
À l'ouverture de l'élément `AddressEditor`, un message d'erreur apparaît en console indiquant : 
`The prop isCertified is marked as required in CertificationButton, but its value is undefined `

Cette PR ajoute une valeur par défaut à la propriété `isCertified` de l'élément `CertificationButton` lorsqu'il n'y a pas de valeur initiale, c’est-à-dire lors de la création d'un numéro.

Fix #404 