### PR TITLE
Corrige le problème de typage de "voie" dans "numeroEditor"

### DIFF
--- a/components/bal/numero-editor.js
+++ b/components/bal/numero-editor.js
@@ -228,7 +228,10 @@ NumeroEditor.propTypes = {
   initialVoieId: PropTypes.string,
   initialValue: PropTypes.shape({
     numero: PropTypes.number.isRequired,
-    voie: PropTypes.string.isRequired,
+    voie: PropTypes.oneOfType([
+      PropTypes.object, // When "voie" comes from getNumerosToponyme() -> it's an Object with "nomVoie", needed to sort numeros by voie and display nomVoie
+      PropTypes.string // When "voie" comes from getNumeros() -> it's a String (only the id of "voie" is return)
+    ]).isRequired,
     suffixe: PropTypes.string,
     parcelles: PropTypes.array,
     comment: PropTypes.string,


### PR DESCRIPTION
L'API-BAL retourne un objet avec une structure différente que l'on appelle `getNumeros` ou `getNumerosToponyme` .
Toponyme ayant besoin du nom de la voie pour afficher son nom ainsi que pour classer les numéros par nom de voie.

Le typage de la propriété "voie" n'étant pas identique selon l'appel, une erreur apparaissait en console : 
`Invalid prop initialValue.voie of type object supplied to NumeroEditor, expected string`

Nous avons donc décidé d'utiliser `oneOfTypes` exceptionnellement pour éviter une modification qui couterai beaucoup d'appels à l'API.

- Ajout de la propTypes `oneOfType`
- Ajout de commentaire pour justifier son utilisation

fix #405 
